### PR TITLE
feat: support custom Embed data with provider-specific types

### DIFF
--- a/src/generateTypes.ts
+++ b/src/generateTypes.ts
@@ -5,11 +5,13 @@ import { BLANK_LINE_IDENTIFIER, NON_EDITABLE_FILE_HEADER } from "./constants";
 import { addTypeAliasForCustomType } from "./lib/addTypeAliasForCustomType";
 import { addTypeAliasForSharedSlice } from "./lib/addTypeAliasForSharedSlice";
 import { getSourceFileText } from "./lib/getSourceFileText";
+import { FieldConfigs } from "./types";
 
 export type GenerateTypesConfig = {
 	customTypeModels?: CustomTypeModel[];
 	sharedSliceModels?: SharedSliceModel[];
 	langIDs?: string[];
+	fieldConfigs?: FieldConfigs;
 };
 
 export const generateTypes = (config: GenerateTypesConfig = {}) => {
@@ -43,7 +45,8 @@ export const generateTypes = (config: GenerateTypesConfig = {}) => {
 			addTypeAliasForCustomType({
 				model,
 				sourceFile,
-				langIDs: config.langIDs,
+				langIDs: config.langIDs || [],
+				fieldConfigs: config.fieldConfigs || {},
 			});
 		}
 	}
@@ -53,6 +56,7 @@ export const generateTypes = (config: GenerateTypesConfig = {}) => {
 			addTypeAliasForSharedSlice({
 				model,
 				sourceFile,
+				fieldConfigs: config.fieldConfigs || {},
 			});
 		}
 	}

--- a/src/lib/addTypeAliasForCustomType.ts
+++ b/src/lib/addTypeAliasForCustomType.ts
@@ -5,6 +5,7 @@ import type {
 	InterfaceDeclaration,
 } from "ts-morph";
 import { CUSTOM_TYPES_DOCUMENTATION_URL } from "../constants";
+import { FieldConfigs } from "../types";
 
 import { addInterfacePropertiesForFields } from "./addInterfacePropertiesForFields";
 import { pascalCase } from "./pascalCase";
@@ -18,13 +19,15 @@ const collectCustomTypeFields = (
 type AddTypeAliasForCustomTypeConfig = {
 	model: CustomTypeModel;
 	sourceFile: SourceFile;
-	langIDs?: string[];
+	langIDs: string[];
+	fieldConfigs: FieldConfigs;
 };
 
 export const addTypeAliasForCustomType = ({
 	model,
 	sourceFile,
-	langIDs = [],
+	langIDs,
+	fieldConfigs,
 }: AddTypeAliasForCustomTypeConfig): TypeAliasDeclaration => {
 	const { uid: uidField, ...fields } = collectCustomTypeFields(model);
 	const hasDataFields = Object.keys(fields).length > 0;
@@ -50,6 +53,7 @@ export const addTypeAliasForCustomType = ({
 					model: model,
 				},
 			],
+			fieldConfigs,
 		});
 	} else {
 		dataInterface = sourceFile.addTypeAlias({

--- a/src/lib/addTypeAliasForSharedSlice.ts
+++ b/src/lib/addTypeAliasForSharedSlice.ts
@@ -10,10 +10,12 @@ import { buildSharedSliceInterfaceName } from "./buildSharedSliceInterfaceName";
 import { pascalCase } from "./pascalCase";
 import { getHumanReadableFieldPath } from "./getHumanReadableFieldPath";
 import { SHARED_SLICES_DOCUMENTATION_URL } from "../constants";
+import { FieldConfigs } from "../types";
 
 type AddTypeAliasForSharedSliceConfig = {
 	model: SharedSliceModel;
 	sourceFile: SourceFile;
+	fieldConfigs: FieldConfigs;
 };
 
 export const addTypeAliasForSharedSlice = (
@@ -65,6 +67,7 @@ export const addTypeAliasForSharedSlice = (
 						label: "Primary",
 					},
 				],
+				fieldConfigs: config.fieldConfigs,
 			});
 		}
 
@@ -111,6 +114,7 @@ export const addTypeAliasForSharedSlice = (
 						label: "Items",
 					},
 				],
+				fieldConfigs: config.fieldConfigs,
 			});
 		}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,3 +16,9 @@ export type PathElement<
 	model?: Model;
 	label?: string;
 };
+
+export type FieldConfigs = {
+	embed?: {
+		providerTypes?: Record<string, string>;
+	};
+};

--- a/test/generateTypes-embed.test.ts
+++ b/test/generateTypes-embed.test.ts
@@ -1,8 +1,12 @@
 import test from "ava";
 import * as prismicM from "@prismicio/mock";
+import { stripIndent } from "common-tags";
 
 import { macroBasicFieldType } from "./__testutils__/macroBasicFieldType";
 import { macroBasicFieldDocs } from "./__testutils__/macroBasicFieldDocs";
+import { parseSourceFile } from "./__testutils__/parseSourceFile";
+
+import * as lib from "../src";
 
 test(
 	"correctly typed",
@@ -10,6 +14,43 @@ test(
 	(t) => prismicM.model.embed({ seed: t.title }),
 	"prismicT.EmbedField",
 );
+
+test("can be customized with provider-specific types", (t) => {
+	const model = prismicM.model.customType({
+		seed: t.title,
+		id: "foo",
+		fields: {
+			bar: prismicM.model.embed({ seed: t.title }),
+		},
+	});
+
+	const res = lib.generateTypes({
+		customTypeModels: [model],
+		fieldConfigs: {
+			embed: {
+				providerTypes: {
+					YouTube: "YouTubeType",
+					Vimeo: "VimeoType",
+				},
+			},
+		},
+	});
+	const file = parseSourceFile(res);
+	const property = file
+		.getInterfaceOrThrow("FooDocumentData")
+		.getPropertyOrThrow("bar");
+
+	t.is(
+		property.getTypeNodeOrThrow().getText({ trimLeadingIndentation: true }),
+		stripIndent`
+			prismicT.EmbedField<prismicT.AnyOEmbed & prismicT.OEmbedExtra & (({
+			    provider_name: "YouTube";
+			} & YouTubeType) | ({
+			    provider_name: "Vimeo";
+			} & VimeoType))>
+		`,
+	);
+});
 
 test("correctly documented", macroBasicFieldDocs, (t) =>
 	prismicM.model.embed({ seed: t.title }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds the ability to type Embed fields with custom provider-specific types.

For example, if you expect YouTube links to be provided via an Embed field, and you know the oEmbed data that will be provided, you can configure the output to include your custom type.

Custom types can be provided to `generateTypes()`'s `fieldConfigs.embed.providerTypes` option:

```typescript
const model = prismicM.model.customType({
	seed: t.title,
	id: "foo",
	fields: {
		bar: prismicM.model.embed({ seed: t.title }),
	},
});

const types = generateTypes({
	customTypeModels: [model],
	fieldConfigs: {
		embed: {
			providerTypes: {
				YouTube: "YouTubeType",
				Vimeo: "VimeoType",
			},
		},
	},
});
```

This will provide the following output (this is not the full output, only the relevant part):

```typescript
interface FooDocumentData {
	bar: prismicT.EmbedField<
		prismicT.AnyOEmbed &
			prismicT.OEmbedExtra &
			(
				| ({
						provider_name: "YouTube",
				  } & YouTubeType)
				| ({
						provider_name: "Vimeo",
				  } & VimeoType)
			)
	>;
}
```

The Embed field can then be type-narrowed by checking `provider_name` against a string constant.

If no provider-specific types are given, the field will be typed as `prismicT.EmbedField`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐦
