### PR TITLE
feat: support custom Integration Fields data with catalog-specific types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"prismic-ts-codegen": "bin/cli.mjs"
 			},
 			"devDependencies": {
-				"@prismicio/mock": "^0.0.7",
+				"@prismicio/mock": "^0.0.8",
 				"@prismicio/types": "^0.1.25",
 				"@size-limit/preset-small-lib": "^7.0.8",
 				"@types/common-tags": "^1.8.1",
@@ -624,9 +624,9 @@
 			}
 		},
 		"node_modules/@prismicio/mock": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.0.7.tgz",
-			"integrity": "sha512-8qNmBQSA7kwm6e7giO8kxE2alUeAt7pa6ZH7QaCTDEaC7/78T++y3YR2LVjzH/JZrS0mqkBZOQL2hCav/j+5BA==",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.0.8.tgz",
+			"integrity": "sha512-Nt836Ree2HgS/eMzAwfXJkxOzwJDZqk8G28U/a3nt8QIhFBlwp0p5bLcE8JgX5U7CFvN/Mp5pl03UWCqaTbQ9w==",
 			"dev": true,
 			"dependencies": {
 				"@prismicio/types": "^0.1.25",
@@ -9629,9 +9629,9 @@
 			}
 		},
 		"@prismicio/mock": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.0.7.tgz",
-			"integrity": "sha512-8qNmBQSA7kwm6e7giO8kxE2alUeAt7pa6ZH7QaCTDEaC7/78T++y3YR2LVjzH/JZrS0mqkBZOQL2hCav/j+5BA==",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.0.8.tgz",
+			"integrity": "sha512-Nt836Ree2HgS/eMzAwfXJkxOzwJDZqk8G28U/a3nt8QIhFBlwp0p5bLcE8JgX5U7CFvN/Mp5pl03UWCqaTbQ9w==",
 			"dev": true,
 			"requires": {
 				"@prismicio/types": "^0.1.25",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"ts-morph": "^13.0.3"
 	},
 	"devDependencies": {
-		"@prismicio/mock": "^0.0.7",
+		"@prismicio/mock": "^0.0.8",
 		"@prismicio/types": "^0.1.25",
 		"@size-limit/preset-small-lib": "^7.0.8",
 		"@types/common-tags": "^1.8.1",

--- a/src/lib/addInterfacePropertiesForFields.ts
+++ b/src/lib/addInterfacePropertiesForFields.ts
@@ -156,9 +156,16 @@ const addInterfacePropertyFromField = (
 		}
 
 		case "IntegrationFields": {
+			const catalogType =
+				config.fieldConfigs.integrationFields?.catalogTypes?.[
+					config.model.config.catalog
+				];
+
 			config.interface.addProperty({
 				name: config.id,
-				type: "prismicT.IntegrationFields",
+				type: catalogType
+					? `prismicT.IntegrationFields<${catalogType}>`
+					: "prismicT.IntegrationFields",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,4 +21,7 @@ export type FieldConfigs = {
 	embed?: {
 		providerTypes?: Record<string, string>;
 	};
+	integrationFields?: {
+		catalogTypes?: Record<string, string>;
+	};
 };

--- a/test/generateTypes-integrationFields.test.ts
+++ b/test/generateTypes-integrationFields.test.ts
@@ -3,6 +3,9 @@ import * as prismicM from "@prismicio/mock";
 
 import { macroBasicFieldType } from "./__testutils__/macroBasicFieldType";
 import { macroBasicFieldDocs } from "./__testutils__/macroBasicFieldDocs";
+import { parseSourceFile } from "./__testutils__/parseSourceFile";
+
+import * as lib from "../src";
 
 test(
 	"correctly typed",
@@ -10,6 +13,46 @@ test(
 	(t) => prismicM.model.integrationFields({ seed: t.title }),
 	"prismicT.IntegrationFields",
 );
+
+test("can be customized with catalog-specific types", (t) => {
+	const model = prismicM.model.customType({
+		seed: t.title,
+		id: "foo",
+		fields: {
+			bar: prismicM.model.integrationFields({
+				seed: t.title,
+				catalog: "abc",
+			}),
+			baz: prismicM.model.integrationFields({
+				seed: t.title,
+				catalog: "def",
+			}),
+		},
+	});
+
+	const types = lib.generateTypes({
+		customTypeModels: [model],
+		fieldConfigs: {
+			integrationFields: {
+				catalogTypes: {
+					abc: "AbcType",
+					def: "DefType",
+				},
+			},
+		},
+	});
+	const file = parseSourceFile(types);
+	const dataInterface = file.getInterfaceOrThrow("FooDocumentData");
+
+	t.is(
+		dataInterface.getPropertyOrThrow("bar").getTypeNodeOrThrow().getText(),
+		"prismicT.IntegrationFields<AbcType>",
+	);
+	t.is(
+		dataInterface.getPropertyOrThrow("baz").getTypeNodeOrThrow().getText(),
+		"prismicT.IntegrationFields<DefType>",
+	);
+});
 
 test("correctly documented", macroBasicFieldDocs, (t) =>
 	prismicM.model.integrationFields({ seed: t.title }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds the ability to type Integration Fields fields with custom catalog-specific types.

For example, if you know the object type returned by a Shopify catalog, you can configure the output to include your custom type.

Custom types can be provided to `generateTypes()`'s `fieldConfigs.integrationFields.catalogTypes` option:

```typescript
const model = prismicM.model.customType({
	seed: t.title,
	id: "foo",
	fields: {
		bar: prismicM.model.integrationFields({
			seed: t.title,
			catalog: "baz"
		}),
	},
});

const types = generateTypes({
	customTypeModels: [model],
	fieldConfigs: {
		integrationFields: {
			catalogTypes: {
				baz: "BazType",
			},
		},
	},
});
```

This will provide the following output (this is not the full output, only the relevant part):

```typescript
interface FooDocumentData {
	bar: prismicT.IntegrationFields<BazType>;
}
```

If no provider-specific types are given, the field will be typed as `prismicT.IntegrationFields`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐤
