### PR TITLE
fix: support fields with hyphenated API IDs

### DIFF
--- a/src/lib/addInterfacePropertiesForFields.ts
+++ b/src/lib/addInterfacePropertiesForFields.ts
@@ -588,7 +588,7 @@ export const addInterfacePropertiesForFields = (
 	for (const name in config.fields) {
 		addInterfacePropertyFromField({
 			...config,
-			id: name,
+			id: name.includes("-") ? `"${name}"` : name,
 			model: config.fields[name],
 		});
 	}

--- a/test/generateTypes-customType.test.ts
+++ b/test/generateTypes-customType.test.ts
@@ -46,6 +46,27 @@ test("generates a Custom Type type", (t) => {
 	}, "contains a FooDocumentData interface");
 });
 
+test("handles hyphenated properties", (t) => {
+	const res = lib.generateTypes({
+		customTypeModels: [
+			prismicM.model.customType({
+				seed: t.title,
+				id: "foo-hyphenated",
+				fields: {},
+			}),
+		],
+	});
+
+	const file = parseSourceFile(res);
+	const type = file
+		.getTypeAliasOrThrow("FooHyphenatedDocument")
+		.getTypeNodeOrThrow();
+	t.is(
+		type.getText(),
+		'prismicT.PrismicDocumentWithoutUID<Simplify<FooHyphenatedDocumentData>, "foo-hyphenated", Lang>',
+	);
+});
+
 test("uses PrismicDocumentWithUID when model contains a UID field", (t) => {
 	const res = lib.generateTypes({
 		customTypeModels: [

--- a/test/generateTypes-customType.test.ts
+++ b/test/generateTypes-customType.test.ts
@@ -46,27 +46,6 @@ test("generates a Custom Type type", (t) => {
 	}, "contains a FooDocumentData interface");
 });
 
-test("handles hyphenated properties", (t) => {
-	const res = lib.generateTypes({
-		customTypeModels: [
-			prismicM.model.customType({
-				seed: t.title,
-				id: "foo-hyphenated",
-				fields: {},
-			}),
-		],
-	});
-
-	const file = parseSourceFile(res);
-	const type = file
-		.getTypeAliasOrThrow("FooHyphenatedDocument")
-		.getTypeNodeOrThrow();
-	t.is(
-		type.getText(),
-		'prismicT.PrismicDocumentWithoutUID<Simplify<FooHyphenatedDocumentData>, "foo-hyphenated", Lang>',
-	);
-});
-
 test("uses PrismicDocumentWithUID when model contains a UID field", (t) => {
 	const res = lib.generateTypes({
 		customTypeModels: [
@@ -167,4 +146,29 @@ test("includes specific lang IDs if given", (t) => {
 		.getText();
 
 	t.is(langDefault, '"en-us" | "fr-fr"');
+});
+
+test("handles hyphenated fields", (t) => {
+	const res = lib.generateTypes({
+		customTypeModels: [
+			prismicM.model.customType({
+				seed: t.title,
+				id: "foo",
+				fields: {
+					"hyphenated-field": prismicM.model.keyText({ seed: t.title }),
+				},
+			}),
+		],
+	});
+
+	const file = parseSourceFile(res);
+	const dataInterface = file.getInterfaceOrThrow("FooDocumentData");
+
+	t.is(
+		dataInterface
+			.getPropertyOrThrow('"hyphenated-field"')
+			.getTypeNodeOrThrow()
+			.getText(),
+		"prismicT.KeyTextField",
+	);
 });

--- a/test/generateTypes-group.test.ts
+++ b/test/generateTypes-group.test.ts
@@ -65,3 +65,30 @@ test("creates an interface for a group item containing its fields", (t) => {
 test("correctly documented", macroBasicFieldDocs, (t) =>
 	prismicM.model.boolean({ seed: t.title }),
 );
+
+test("handles hyphenated fields", (t) => {
+	const model = prismicM.model.customType({
+		seed: t.title,
+		id: "foo",
+		fields: {
+			bar: prismicM.model.group({
+				seed: t.title,
+				fields: {
+					"hyphenated-field": prismicM.model.keyText({ seed: t.title }),
+				},
+			}),
+		},
+	});
+
+	const types = lib.generateTypes({ customTypeModels: [model] });
+	const file = parseSourceFile(types);
+	const itemInterface = file.getInterfaceOrThrow("FooDocumentDataBarItem");
+
+	t.is(
+		itemInterface
+			.getPropertyOrThrow('"hyphenated-field"')
+			.getTypeNodeOrThrow()
+			.getText(),
+		"prismicT.KeyTextField",
+	);
+});

--- a/test/generateTypes-sharedSlice.test.ts
+++ b/test/generateTypes-sharedSlice.test.ts
@@ -241,9 +241,9 @@ test("creates an interface for a Slice variation's items fields", (t) => {
 	const types = lib.generateTypes({ sharedSliceModels: [model] });
 	const file = parseSourceFile(types);
 
-	const primaryInterface = file.getInterfaceOrThrow("FooSliceBarItem");
+	const itemInterface = file.getInterfaceOrThrow("FooSliceBarItem");
 	t.is(
-		primaryInterface.getPropertyOrThrow("def").getTypeNodeOrThrow().getText(),
+		itemInterface.getPropertyOrThrow("def").getTypeNodeOrThrow().getText(),
 		"prismicT.SelectField",
 	);
 });
@@ -269,5 +269,46 @@ test("handles Shared Slice with no variations", (t) => {
 			.getTypeNodeOrThrow()
 			.getText(),
 		"never",
+	);
+});
+
+test("handles hyphenated fields", (t) => {
+	const model = prismicM.model.sharedSlice({
+		seed: t.title,
+		id: "foo",
+		variations: [
+			prismicM.model.sharedSliceVariation({
+				seed: t.title,
+				id: "bar",
+				primaryFields: {
+					"hyphenated-field": prismicM.model.keyText({ seed: t.title }),
+				},
+				itemsFields: {
+					"hyphenated-field": prismicM.model.select({ seed: t.title }),
+				},
+			}),
+		],
+	});
+
+	const types = lib.generateTypes({ sharedSliceModels: [model] });
+	const file = parseSourceFile(types);
+
+	const primaryInterface = file.getInterfaceOrThrow("FooSliceBarPrimary");
+	const itemInterface = file.getInterfaceOrThrow("FooSliceBarItem");
+
+	t.is(
+		primaryInterface
+			.getPropertyOrThrow('"hyphenated-field"')
+			.getTypeNodeOrThrow()
+			.getText(),
+		"prismicT.KeyTextField",
+	);
+
+	t.is(
+		itemInterface
+			.getPropertyOrThrow('"hyphenated-field"')
+			.getTypeNodeOrThrow()
+			.getText(),
+		"prismicT.SelectField",
 	);
 });

--- a/test/generateTypes-sliceZone.test.ts
+++ b/test/generateTypes-sliceZone.test.ts
@@ -296,3 +296,52 @@ test("creates an interface for a Slice's items fields", (t) => {
 		"prismicT.SelectField",
 	);
 });
+
+test("handles hyphenated fields", (t) => {
+	const model = prismicM.model.customType({
+		seed: t.title,
+		id: "foo",
+		fields: {
+			bar: prismicM.model.sliceZone({
+				seed: t.title,
+				choices: {
+					baz: prismicM.model.slice({
+						seed: t.title,
+						nonRepeatFields: {
+							"hyphenated-field": prismicM.model.keyText({ seed: t.title }),
+						},
+						repeatFields: {
+							"hyphenated-field": prismicM.model.select({ seed: t.title }),
+						},
+					}),
+				},
+			}),
+		},
+	});
+
+	const types = lib.generateTypes({ customTypeModels: [model] });
+	const file = parseSourceFile(types);
+
+	const primaryInterface = file.getInterfaceOrThrow(
+		"FooDocumentDataBarBazSlicePrimary",
+	);
+	const itemInterface = file.getInterfaceOrThrow(
+		"FooDocumentDataBarBazSliceItem",
+	);
+
+	t.is(
+		primaryInterface
+			.getPropertyOrThrow('"hyphenated-field"')
+			.getTypeNodeOrThrow()
+			.getText(),
+		"prismicT.KeyTextField",
+	);
+
+	t.is(
+		itemInterface
+			.getPropertyOrThrow('"hyphenated-field"')
+			.getTypeNodeOrThrow()
+			.getText(),
+		"prismicT.SelectField",
+	);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Closes https://github.com/prismicio/prismic-ts-codegen/issues/6

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Codegen was failing if a field name included hyphens.
This PR sets the value correctly using a template literal and wrapping in quotes.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

```typescript
interface Example {
  my-field: string;
}
```
</td>
<td>

```typescript
interface Example {
  "my-field": string;
}
```
</td>
</tr>
</table>

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
