### PR TITLE
feat: add a Custom Type field's tab name to its description

### DIFF
--- a/src/lib/addInterfacePropertiesForFields.ts
+++ b/src/lib/addInterfacePropertiesForFields.ts
@@ -26,9 +26,10 @@ type AddInterfacePropertyFromFieldConfig = {
 		...PathElement<CustomTypeModelField | CustomTypeModelSlice>[],
 	];
 	fieldConfigs: FieldConfigs;
+	tabID?: string;
 };
 
-const addInterfacePropertyFromField = (
+const addInterfacePropertyForField = (
 	config: AddInterfacePropertyFromFieldConfig,
 ) => {
 	switch (config.model.type) {
@@ -45,6 +46,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -59,6 +61,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -73,6 +76,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -105,6 +109,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -119,6 +124,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -138,6 +144,7 @@ const addInterfacePropertyFromField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
+						tabID: config.tabID,
 					}),
 				});
 			} else {
@@ -148,6 +155,7 @@ const addInterfacePropertyFromField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
+						tabID: config.tabID,
 					}),
 				});
 			}
@@ -170,6 +178,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -192,6 +201,7 @@ const addInterfacePropertyFromField = (
 							id: config.id,
 							model: config.model,
 							path: config.path,
+							tabID: config.tabID,
 						}),
 					});
 
@@ -206,6 +216,7 @@ const addInterfacePropertyFromField = (
 							id: config.id,
 							model: config.model,
 							path: config.path,
+							tabID: config.tabID,
 						}),
 					});
 
@@ -220,6 +231,7 @@ const addInterfacePropertyFromField = (
 							id: config.id,
 							model: config.model,
 							path: config.path,
+							tabID: config.tabID,
 						}),
 					});
 				}
@@ -236,6 +248,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -257,6 +270,7 @@ const addInterfacePropertyFromField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
+						tabID: config.tabID,
 					}),
 				});
 			} else {
@@ -267,6 +281,7 @@ const addInterfacePropertyFromField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
+						tabID: config.tabID,
 					}),
 				});
 			}
@@ -288,6 +303,7 @@ const addInterfacePropertyFromField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
+						tabID: config.tabID,
 					}),
 				});
 			} else {
@@ -298,6 +314,7 @@ const addInterfacePropertyFromField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
+						tabID: config.tabID,
 					}),
 				});
 			}
@@ -313,6 +330,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -327,6 +345,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -378,6 +397,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -558,6 +578,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 
@@ -572,6 +593,7 @@ const addInterfacePropertyFromField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
+					tabID: config.tabID,
 				}),
 			});
 		}
@@ -583,16 +605,18 @@ type AddInterfacePropertiesForFieldsConfig = Omit<
 	"id" | "model"
 > & {
 	fields: Record<string, AddInterfacePropertyFromFieldConfig["model"]>;
+	tabID?: string;
 };
 
 export const addInterfacePropertiesForFields = (
 	config: AddInterfacePropertiesForFieldsConfig,
 ) => {
 	for (const name in config.fields) {
-		addInterfacePropertyFromField({
+		addInterfacePropertyForField({
 			...config,
 			id: name.includes("-") ? `"${name}"` : name,
 			model: config.fields[name],
+			tabID: config.tabID,
 		});
 	}
 };

--- a/src/lib/addInterfacePropertiesForFields.ts
+++ b/src/lib/addInterfacePropertiesForFields.ts
@@ -26,7 +26,7 @@ type AddInterfacePropertyFromFieldConfig = {
 		...PathElement<CustomTypeModelField | CustomTypeModelSlice>[],
 	];
 	fieldConfigs: FieldConfigs;
-	tabID?: string;
+	tabName?: string;
 };
 
 const addInterfacePropertyForField = (
@@ -46,7 +46,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -61,7 +61,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -76,7 +76,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -109,7 +109,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -124,7 +124,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -144,7 +144,7 @@ const addInterfacePropertyForField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
-						tabID: config.tabID,
+						tabName: config.tabName,
 					}),
 				});
 			} else {
@@ -155,7 +155,7 @@ const addInterfacePropertyForField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
-						tabID: config.tabID,
+						tabName: config.tabName,
 					}),
 				});
 			}
@@ -178,7 +178,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -201,7 +201,7 @@ const addInterfacePropertyForField = (
 							id: config.id,
 							model: config.model,
 							path: config.path,
-							tabID: config.tabID,
+							tabName: config.tabName,
 						}),
 					});
 
@@ -216,7 +216,7 @@ const addInterfacePropertyForField = (
 							id: config.id,
 							model: config.model,
 							path: config.path,
-							tabID: config.tabID,
+							tabName: config.tabName,
 						}),
 					});
 
@@ -231,7 +231,7 @@ const addInterfacePropertyForField = (
 							id: config.id,
 							model: config.model,
 							path: config.path,
-							tabID: config.tabID,
+							tabName: config.tabName,
 						}),
 					});
 				}
@@ -248,7 +248,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -270,7 +270,7 @@ const addInterfacePropertyForField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
-						tabID: config.tabID,
+						tabName: config.tabName,
 					}),
 				});
 			} else {
@@ -281,7 +281,7 @@ const addInterfacePropertyForField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
-						tabID: config.tabID,
+						tabName: config.tabName,
 					}),
 				});
 			}
@@ -303,7 +303,7 @@ const addInterfacePropertyForField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
-						tabID: config.tabID,
+						tabName: config.tabName,
 					}),
 				});
 			} else {
@@ -314,7 +314,7 @@ const addInterfacePropertyForField = (
 						id: config.id,
 						model: config.model,
 						path: config.path,
-						tabID: config.tabID,
+						tabName: config.tabName,
 					}),
 				});
 			}
@@ -330,7 +330,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -345,7 +345,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -397,7 +397,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -578,7 +578,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 
@@ -593,7 +593,7 @@ const addInterfacePropertyForField = (
 					id: config.id,
 					model: config.model,
 					path: config.path,
-					tabID: config.tabID,
+					tabName: config.tabName,
 				}),
 			});
 		}
@@ -605,7 +605,7 @@ type AddInterfacePropertiesForFieldsConfig = Omit<
 	"id" | "model"
 > & {
 	fields: Record<string, AddInterfacePropertyFromFieldConfig["model"]>;
-	tabID?: string;
+	tabName?: string;
 };
 
 export const addInterfacePropertiesForFields = (
@@ -616,7 +616,7 @@ export const addInterfacePropertiesForFields = (
 			...config,
 			id: name.includes("-") ? `"${name}"` : name,
 			model: config.fields[name],
-			tabID: config.tabID,
+			tabName: config.tabName,
 		});
 	}
 };

--- a/src/lib/addTypeAliasForCustomType.ts
+++ b/src/lib/addTypeAliasForCustomType.ts
@@ -43,18 +43,26 @@ export const addTypeAliasForCustomType = ({
 				},
 			],
 		});
-		addInterfacePropertiesForFields({
-			fields,
-			interface: dataInterface,
-			sourceFile: sourceFile,
-			path: [
-				{
-					id: model.id,
-					model: model,
-				},
-			],
-			fieldConfigs,
-		});
+
+		for (const tabID in model.json) {
+			// This is destructured to ensure the UID field is
+			// ignored.
+			const { uid: _uidField, ...tabFields } = model.json[tabID];
+
+			addInterfacePropertiesForFields({
+				fields: tabFields,
+				interface: dataInterface,
+				sourceFile: sourceFile,
+				path: [
+					{
+						id: model.id,
+						model: model,
+					},
+				],
+				fieldConfigs,
+				tabID,
+			});
+		}
 	} else {
 		dataInterface = sourceFile.addTypeAlias({
 			name: pascalCase(`${model.id} Document Data`),

--- a/src/lib/addTypeAliasForCustomType.ts
+++ b/src/lib/addTypeAliasForCustomType.ts
@@ -44,10 +44,10 @@ export const addTypeAliasForCustomType = ({
 			],
 		});
 
-		for (const tabID in model.json) {
+		for (const tabName in model.json) {
 			// This is destructured to ensure the UID field is
 			// ignored.
-			const { uid: _uidField, ...tabFields } = model.json[tabID];
+			const { uid: _uidField, ...tabFields } = model.json[tabName];
 
 			addInterfacePropertiesForFields({
 				fields: tabFields,
@@ -60,7 +60,7 @@ export const addTypeAliasForCustomType = ({
 					},
 				],
 				fieldConfigs,
-				tabID,
+				tabName,
 			});
 		}
 	} else {

--- a/src/lib/buildFieldDocs.ts
+++ b/src/lib/buildFieldDocs.ts
@@ -21,6 +21,7 @@ type BuildFieldDocsConfig = {
 		PathElement<CustomTypeModel | SharedSliceModel>,
 		...PathElement<CustomTypeModelField | CustomTypeModelSlice>[],
 	];
+	tabID?: string;
 };
 
 export const buildFieldDocs = (
@@ -63,6 +64,7 @@ export const buildFieldDocs = (
 					placeholder,
 					defaultValue,
 					apiIDPath,
+					tabID: config.tabID,
 					documentationURL: getFieldDocumentationURL({ model: config.model }),
 				});
 			},

--- a/src/lib/buildFieldDocs.ts
+++ b/src/lib/buildFieldDocs.ts
@@ -21,7 +21,7 @@ type BuildFieldDocsConfig = {
 		PathElement<CustomTypeModel | SharedSliceModel>,
 		...PathElement<CustomTypeModelField | CustomTypeModelSlice>[],
 	];
-	tabID?: string;
+	tabName?: string;
 };
 
 export const buildFieldDocs = (
@@ -64,7 +64,7 @@ export const buildFieldDocs = (
 					placeholder,
 					defaultValue,
 					apiIDPath,
-					tabID: config.tabID,
+					tabName: config.tabName,
 					documentationURL: getFieldDocumentationURL({ model: config.model }),
 				});
 			},

--- a/src/lib/writeFieldDocsDescription.ts
+++ b/src/lib/writeFieldDocsDescription.ts
@@ -7,7 +7,7 @@ type BuildFieldDocsConfig = {
 	defaultValue?: string | boolean;
 	placeholder?: string;
 	apiIDPath?: string;
-	tabID?: string;
+	tabName?: string;
 	documentationURL?: string;
 };
 
@@ -41,8 +41,8 @@ export const writeFieldDocsDescription = (
 		config.writer.writeLine(`- **API ID Path**: ${config.apiIDPath}`);
 	}
 
-	if (config.tabID) {
-		config.writer.writeLine(`- **Tab ID**: ${config.tabID}`);
+	if (config.tabName) {
+		config.writer.writeLine(`- **Tab**: ${config.tabName}`);
 	}
 
 	if (config.documentationURL) {

--- a/src/lib/writeFieldDocsDescription.ts
+++ b/src/lib/writeFieldDocsDescription.ts
@@ -7,6 +7,7 @@ type BuildFieldDocsConfig = {
 	defaultValue?: string | boolean;
 	placeholder?: string;
 	apiIDPath?: string;
+	tabID?: string;
 	documentationURL?: string;
 };
 
@@ -38,6 +39,10 @@ export const writeFieldDocsDescription = (
 
 	if (config.apiIDPath) {
 		config.writer.writeLine(`- **API ID Path**: ${config.apiIDPath}`);
+	}
+
+	if (config.tabID) {
+		config.writer.writeLine(`- **Tab ID**: ${config.tabID}`);
 	}
 
 	if (config.documentationURL) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a Custom Type field's tab name to its description. Since Shared Slices are generated as a shared type potentially used by multiple Custom Types, Shared Slice fields do not list their tab names.

A field's description looks like this:

```
/**
 * main_title field in *Tabbed Page*
 *
 * - **Field Type**: Title
 * - **Placeholder**: *None*
 * - **API ID Path**: tabbed_page.main_title
 * - **Tab**: Main
 * - **Documentation**: https://prismic.io/docs/core-concepts/rich-text-title
 */
```

Note the "Tab" bullet point.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
