### PR TITLE
feat: add ability to generate `@prismicio/client` CreateClient interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
 	"peerDependencies": {
 		"@prismicio/types": "^0.1.25"
 	},
+	"optionalDependencies": {
+		"@prismicio/client": "^6.6"
+	},
 	"engines": {
 		"node": ">=12.7.0"
 	},

--- a/src/cli/configSchema.ts
+++ b/src/cli/configSchema.ts
@@ -3,7 +3,19 @@ import Joi from "joi";
 import { Config } from "./types";
 
 export const configSchema = Joi.object<Config>({
-	repositoryName: Joi.string(),
+	repositoryName: Joi.string()
+		.when("includeClientInterface", {
+			is: true,
+			then: Joi.required(),
+		})
+		.when("locales.fetchFromRepository", {
+			is: true,
+			then: Joi.required(),
+		})
+		.when("models.fetchFromRepository", {
+			is: true,
+			then: Joi.required(),
+		}),
 	accessToken: Joi.string(),
 	customTypesAPIToken: Joi.string(),
 
@@ -36,29 +48,6 @@ export const configSchema = Joi.object<Config>({
 			catalogTypes: Joi.object().pattern(Joi.string(), Joi.string().required()),
 		}),
 	}),
-})
-	.when(
-		Joi.object({
-			locales: Joi.object({
-				fetchFromRepository: Joi.valid(true),
-			}),
-		}),
-		{
-			then: Joi.object({
-				repositoryName: Joi.required(),
-			}),
-		},
-	)
-	.when(
-		Joi.object({
-			models: Joi.object({
-				fetchFromRepository: Joi.valid(true),
-			}),
-		}),
-		{
-			then: Joi.object({
-				repositoryName: Joi.required(),
-				customTypesAPIToken: Joi.required(),
-			}),
-		},
-	);
+
+	includeClientInterface: Joi.boolean(),
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -101,11 +101,24 @@ const main = async () => {
 					config.locales.fetchFromRepository,
 			});
 
-			const types = generateTypes({
-				customTypeModels,
-				sharedSliceModels,
-				localeIDs,
-			});
+			let types;
+			if (config.includeClientInterface && config.repositoryName) {
+				types = generateTypes({
+					repositoryName: config.repositoryName,
+					customTypeModels,
+					sharedSliceModels,
+					localeIDs,
+					includeClientInterface: true,
+				});
+			} else {
+				types = generateTypes({
+					repositoryName: config.repositoryName,
+					customTypeModels,
+					sharedSliceModels,
+					localeIDs,
+					includeClientInterface: false,
+				});
+			}
 
 			if (config.output) {
 				writeFileSync(resolvePath(config.output), types);

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -26,6 +26,17 @@ export type Config = {
 	output?: string;
 
 	/**
+	 * Determines if a `@prismicio/client` interface with automatic typing should
+	 * be included in the output.
+	 *
+	 * If set to `true`, Prismic clients created for this config's Prismic
+	 * repository will automatically be typed with its Custom Types and Slices.
+	 *
+	 * @defaultValue `true`
+	 */
+	includeClientInterface?: boolean;
+
+	/**
 	 * Configuration for languages for the Prismic repository.
 	 *
 	 * It can be configured by providing an array of locale IDs configured for the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds the ability to generate a `@prismicio/client` module augmentation that automatically types a Prismic client.

It is enabled by default if `prismicCodegen.config.ts` contains a `repositoryName` property; `repositoryName` is required to generate the interface. The module generation can be disabled using the `includeClientInterface` option.

```typescript
// prismicCodegen.config.ts

import type { Config } from "prismic-ts-codegen";

const config: Config = {
  repositoryName: "nextjs-starter-prismic-blog",
  output: "./types.generated.ts",
  models: ["./customtypes/**/index.json", "./slices/**/model.json"],

  // `true` by default
  includeClientInterface: false,
};

export default config;
```

For more details on the generated module augmentation and interface, see the **"Client type augmentation"** section of prismicio/prismic-client#238.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
