### PR TITLE
fix(cli): use the `fields` property when generating types

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -107,6 +107,7 @@ const main = async () => {
 				customTypeModels,
 				sharedSliceModels,
 				localeIDs,
+				fieldConfigs: config.fields,
 				clientIntegration: {
 					includeCreateClientInterface: hasCustomTypeModels
 						? config.clientIntegration?.includeCreateClientInterface ?? true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a CLI bug where the `fields` configuration property was ignored when generating types.

**Cause**: The `fields` property was accidentally not passed to the underlying `generateTypes()` function. Oops!

Fixes: #18

Thanks to @chamois-d-or for reporting this bug!

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐦
