### PR TITLE
fix: support fields with a name starting with a number

### DIFF
--- a/src/lib/addInterfacePropertiesForFields.ts
+++ b/src/lib/addInterfacePropertiesForFields.ts
@@ -632,7 +632,7 @@ export const addInterfacePropertiesForFields = (
 	for (const name in config.fields) {
 		addInterfacePropertyForField({
 			...config,
-			id: name.includes("-") ? `"${name}"` : name,
+			id: name.includes("-") || /^[0-9]/.test(name) ? `"${name}"` : name,
 			model: config.fields[name],
 			tabName: config.tabName,
 		});

--- a/test/generateTypes-customType.test.ts
+++ b/test/generateTypes-customType.test.ts
@@ -183,7 +183,7 @@ test("handles fields starting with a number", (t) => {
 				seed: t.title,
 				id: "foo",
 				fields: {
-					"3d-noodle": prismicM.model.keyText({ seed: t.title }),
+					"3d_noodle": prismicM.model.keyText({ seed: t.title }),
 				},
 			}),
 		],
@@ -194,7 +194,7 @@ test("handles fields starting with a number", (t) => {
 
 	t.is(
 		dataInterface
-			.getPropertyOrThrow('"3d-noodle"')
+			.getPropertyOrThrow('"3d_noodle"')
 			.getTypeNodeOrThrow()
 			.getText(),
 		"prismicT.KeyTextField",

--- a/test/generateTypes-customType.test.ts
+++ b/test/generateTypes-customType.test.ts
@@ -175,3 +175,28 @@ test("handles hyphenated fields", (t) => {
 		"prismicT.KeyTextField",
 	);
 });
+
+test("handles fields starting with a number", (t) => {
+	const res = lib.generateTypes({
+		customTypeModels: [
+			prismicM.model.customType({
+				seed: t.title,
+				id: "foo",
+				fields: {
+					"3d-noodle": prismicM.model.keyText({ seed: t.title }),
+				},
+			}),
+		],
+	});
+
+	const file = parseSourceFile(res);
+	const dataInterface = file.getInterfaceOrThrow("FooDocumentData");
+
+	t.is(
+		dataInterface
+			.getPropertyOrThrow('"3d-noodle"')
+			.getTypeNodeOrThrow()
+			.getText(),
+		"prismicT.KeyTextField",
+	);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where `prismic-ts-codegen` would crash if it came across a field API ID starting with a number.

For example, a field with the API ID of `3d-noodle` would cause the following error:

```
ManipulationError: Manipulation error: A syntax error was inserted.

types.d.ts:2910:6 - error TS1351: An identifier or keyword cannot immediately follow a numeric literal.
```

This PR fixes this issue by wrapping those field name properties with quotation parts (e.g. `"3d-noodle"`).

For more details, see #24. Thanks to @AugusDogus for reporting the issue!

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🍝
