### PR TITLE
fix: use `ImageField<never>` rather than `ImageField<null>`

### DIFF
--- a/src/lib/addInterfacePropertiesForFields.ts
+++ b/src/lib/addInterfacePropertiesForFields.ts
@@ -153,7 +153,7 @@ const addInterfacePropertyForField = (
 			} else {
 				config.interface.addProperty({
 					name: config.id,
-					type: "prismicT.ImageField<null>",
+					type: "prismicT.ImageField<never>",
 					docs: buildFieldDocs({
 						id: config.id,
 						model: config.model,

--- a/test/generateTypes-image.test.ts
+++ b/test/generateTypes-image.test.ts
@@ -8,7 +8,7 @@ test(
 	"correctly typed",
 	macroBasicFieldType,
 	(t) => prismicM.model.image({ seed: t.title }),
-	"prismicT.ImageField<null>",
+	"prismicT.ImageField<never>",
 );
 
 test(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR changes the generated type for Image fields without thumbnails to use the latest `@prismicio/types` recommendation.

- OLD: `ImageField<null>`
- NEW: `ImageField<never>`

`null` will continue to work, but it is deprecated in `@prismicio/types`. Similarly, `never` was supported in previous versions of `@prismicio/types`, but it was not the recommended API. That recommendation has changed.

See https://github.com/prismicio/prismic-types/pull/46 for more details.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
