### PR TITLE
fix(cli): support custom configs via `--config/-c` with a default export

### DIFF
--- a/src/cli/loadConfig.ts
+++ b/src/cli/loadConfig.ts
@@ -6,6 +6,12 @@ import type { Config } from "./types";
 
 const jiti = _jiti(process.cwd());
 
+const loadModuleWithJiti = <TModule>(id: string): TModule => {
+	const mod = jiti(id) as TModule | { default: TModule };
+
+	return "default" in mod ? mod.default : mod;
+};
+
 const DEFAULT_CONFIG_PATHS = [
 	"prismicCodegen.config.ts",
 	"prismicCodegen.config.js",
@@ -18,18 +24,14 @@ type LoadConfigConfig = {
 export const loadConfig = (config: LoadConfigConfig): Config => {
 	if (config.path) {
 		if (existsSync(config.path)) {
-			return jiti(config.path);
+			return loadModuleWithJiti(resolvePath(config.path));
 		} else {
 			throw new Error(`Config file does not exist: ${config.path}`);
 		}
 	} else {
 		for (const configPath of DEFAULT_CONFIG_PATHS) {
 			if (existsSync(configPath)) {
-				const mod = jiti(resolvePath(configPath)) as
-					| Config
-					| { default: Config };
-
-				return "default" in mod ? mod.default : mod;
+				return loadModuleWithJiti(resolvePath(configPath));
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug in the `prismic-ts-codegen` CLI where custom configuration files specified with the `--config/-c` option were loaded incorrectly.

As of this PR, custom configuration files are loaded using the same logic as the default configuration file.

```typescript
// custom-config.ts
import type { Config } from "prismic-ts-codegen";

const config: Config = {
  repositoryName: "qwerty",
  // ...etc.
};

// `export default` is now supported (recommended)
export default config;

// `module.exports` is also supported (not recommended)
module.exports = config;
```

Fixes #31

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐤
