### PR TITLE
feat: set the types provider using the `typesProvider` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [14]
-        typescript: ["4.5", "4.6", "4.7", "4.8", "4.9"]
+        typescript: ["4.7", "4.8", "4.9"]
 
     steps:
       - name: Set up Node

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Prismic model-to-TypeScript-type generator.
 
 - Converts custom type and shared Slice models to TypeScript types
 - Integrates with other Prismic TypeScript libraries
-- Built on the [`@prismicio/client`][prismic-client] library
+- Built upon the [`@prismicio/client`][prismic-client] library
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@
 
 A Prismic model-to-TypeScript-type generator.
 
-- Converts Custom Type and Shared Slice models to TypeScript types
+- Converts custom type and shared Slice models to TypeScript types
 - Integrates with other Prismic TypeScript libraries
-- Built on the [`@prismicio/client`][prismic-types] library
+- Built on the [`@prismicio/client`][prismic-client] library
 
 ## Install
 
 ```bash
-npm install --save-dev prismic-ts-codegen @prismicio/client
+npm install @prismicio/client
+npm install --save-dev prismic-ts-codegen
 ```
 
 ## Usage
@@ -149,7 +150,7 @@ limitations under the License.
 <!-- Links -->
 
 [prismic]: https://prismic.io
-[prismic-types]: https://github.com/prismicio/prismic-types
+[prismic-client]: https://github.com/prismicio/prismic-client
 
 <!-- TODO: Replace link with a more useful one if available -->
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ A Prismic model-to-TypeScript-type generator.
 
 - Converts Custom Type and Shared Slice models to TypeScript types
 - Integrates with other Prismic TypeScript libraries
-- Built on the [`@prismicio/types`][prismic-types] library
+- Built on the [`@prismicio/client`][prismic-types] library
 
 ## Install
 
 ```bash
-npm install --save-dev prismic-ts-codegen @prismicio/types
+npm install --save-dev prismic-ts-codegen @prismicio/client
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.1.6",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@prismicio/client": "^7.0.0",
 				"@prismicio/custom-types-client": "^1.1.0",
 				"common-tags": "^1.8.2",
 				"fast-glob": "^3.2.12",
@@ -48,11 +49,17 @@
 			"engines": {
 				"node": ">=12.7.0"
 			},
-			"optionalDependencies": {
-				"@prismicio/client": "^6.6"
-			},
 			"peerDependencies": {
+				"@prismicio/client": "^6.6 || ^7",
 				"@prismicio/types": "^0.2"
+			},
+			"peerDependenciesMeta": {
+				"@prismicio/client": {
+					"optional": true
+				},
+				"@prismicio/types": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -895,16 +902,15 @@
 			}
 		},
 		"node_modules/@prismicio/client": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.8.0.tgz",
-			"integrity": "sha512-6E2dGp1zsZRKe9g/YH/vUeKf2OZJqZJGJjTXuI+EjQxNROf0L1aTDxcpcxWRwLbHxFyMxdNAMY4rUyuNzRKY9Q==",
-			"optional": true,
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.0.0.tgz",
+			"integrity": "sha512-T/V2F3zaFvWYt+ITd/casc2F7qik5xuxTABE0NTcGJqsxeX8l/ivv0N9qiY3dsxFrh7qYMlC7gytdUeclmuA+Q==",
 			"dependencies": {
-				"@prismicio/helpers": "^2.3.8",
-				"@prismicio/types": "^0.2.7"
+				"@prismicio/richtext": "^2.1.4",
+				"imgix-url-builder": "^0.0.3"
 			},
 			"engines": {
-				"node": ">=12.13.0"
+				"node": ">=14.15.0"
 			}
 		},
 		"node_modules/@prismicio/custom-types-client": {
@@ -916,20 +922,6 @@
 			},
 			"engines": {
 				"node": ">=14.15.0"
-			}
-		},
-		"node_modules/@prismicio/helpers": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.9.tgz",
-			"integrity": "sha512-p7Y1sG83A2YPZvptfAzuZA8xH1bdM2wGRjqSKW9Qa0rAnBq2OfVKRvwl9OMCZML4eLUMxSEUAEWRVSoKpQnJvA==",
-			"optional": true,
-			"dependencies": {
-				"@prismicio/richtext": "^2.1.4",
-				"@prismicio/types": "^0.2.7",
-				"imgix-url-builder": "^0.0.3"
-			},
-			"engines": {
-				"node": ">=12.7.0"
 			}
 		},
 		"node_modules/@prismicio/mock": {
@@ -949,7 +941,6 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.1.4.tgz",
 			"integrity": "sha512-hyC8XItj+2yMmLGNjg9xGA/lRMO5UgbPF132VFrpZHzHhtIKvHN3iYxCZxnrEoPaTcT6JjA8vWyYLjmmB49bvw==",
-			"optional": true,
 			"dependencies": {
 				"@prismicio/types": "^0.2.7"
 			},
@@ -5419,7 +5410,6 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.3.tgz",
 			"integrity": "sha512-8Oc2Cn4+jF06sEfJcVPlWYfD2F6RjrwIMbk1xEzux8unoB5LsvFc/GL1BQ47HPaeE12ReX2nMUcjUslGYWLxHA==",
-			"optional": true,
 			"engines": {
 				"node": ">=12.7.0"
 			}
@@ -9040,13 +9030,12 @@
 			}
 		},
 		"@prismicio/client": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.8.0.tgz",
-			"integrity": "sha512-6E2dGp1zsZRKe9g/YH/vUeKf2OZJqZJGJjTXuI+EjQxNROf0L1aTDxcpcxWRwLbHxFyMxdNAMY4rUyuNzRKY9Q==",
-			"optional": true,
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.0.0.tgz",
+			"integrity": "sha512-T/V2F3zaFvWYt+ITd/casc2F7qik5xuxTABE0NTcGJqsxeX8l/ivv0N9qiY3dsxFrh7qYMlC7gytdUeclmuA+Q==",
 			"requires": {
-				"@prismicio/helpers": "^2.3.8",
-				"@prismicio/types": "^0.2.7"
+				"@prismicio/richtext": "^2.1.4",
+				"imgix-url-builder": "^0.0.3"
 			}
 		},
 		"@prismicio/custom-types-client": {
@@ -9055,17 +9044,6 @@
 			"integrity": "sha512-nJqWD8RikdMaU+xH8t5Hy6tUBWM57cq1yGofsKUHu/UWySIpgo4SA+1SieD11+xzRr7a1b/a/ThA2imJB0DYfQ==",
 			"requires": {
 				"@prismicio/types": "^0.2.4"
-			}
-		},
-		"@prismicio/helpers": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.9.tgz",
-			"integrity": "sha512-p7Y1sG83A2YPZvptfAzuZA8xH1bdM2wGRjqSKW9Qa0rAnBq2OfVKRvwl9OMCZML4eLUMxSEUAEWRVSoKpQnJvA==",
-			"optional": true,
-			"requires": {
-				"@prismicio/richtext": "^2.1.4",
-				"@prismicio/types": "^0.2.7",
-				"imgix-url-builder": "^0.0.3"
 			}
 		},
 		"@prismicio/mock": {
@@ -9082,7 +9060,6 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.1.4.tgz",
 			"integrity": "sha512-hyC8XItj+2yMmLGNjg9xGA/lRMO5UgbPF132VFrpZHzHhtIKvHN3iYxCZxnrEoPaTcT6JjA8vWyYLjmmB49bvw==",
-			"optional": true,
 			"requires": {
 				"@prismicio/types": "^0.2.7"
 			}
@@ -12402,8 +12379,7 @@
 		"imgix-url-builder": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.3.tgz",
-			"integrity": "sha512-8Oc2Cn4+jF06sEfJcVPlWYfD2F6RjrwIMbk1xEzux8unoB5LsvFc/GL1BQ47HPaeE12ReX2nMUcjUslGYWLxHA==",
-			"optional": true
+			"integrity": "sha512-8Oc2Cn4+jF06sEfJcVPlWYfD2F6RjrwIMbk1xEzux8unoB5LsvFc/GL1BQ47HPaeE12ReX2nMUcjUslGYWLxHA=="
 		},
 		"import-fresh": {
 			"version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	},
 	"dependencies": {
 		"@prismicio/custom-types-client": "^1.1.0",
+		"@prismicio/client": "^7.0.0",
 		"common-tags": "^1.8.2",
 		"fast-glob": "^3.2.12",
 		"jiti": "^1.18.2",
@@ -81,10 +82,16 @@
 		"vitest": "^0.31.1"
 	},
 	"peerDependencies": {
+		"@prismicio/client": "^6.6 || ^7",
 		"@prismicio/types": "^0.2"
 	},
-	"optionalDependencies": {
-		"@prismicio/client": "^6.6"
+	"peerDependenciesMeta": {
+		"@prismicio/client": {
+			"optional": true
+		},
+		"@prismicio/types": {
+			"optional": true
+		}
 	},
 	"engines": {
 		"node": ">=12.7.0"

--- a/src/cli/configSchema.ts
+++ b/src/cli/configSchema.ts
@@ -17,6 +17,8 @@ export const configSchema = Joi.object<Config>({
 
 	output: Joi.string(),
 
+	typesProvider: Joi.string().allow("@prismicio/client", "@prismicio/client"),
+
 	clientIntegration: Joi.object({
 		includeCreateClientInterface: Joi.boolean(),
 		includeContentNamespace: Joi.boolean(),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,7 @@ import { existsSync, writeFileSync } from "fs";
 import meow from "meow";
 import { resolve as resolvePath } from "path";
 
-import { generateTypes } from "../index";
+import { detectTypesProvider, generateTypes } from "../index";
 
 import { configSchema } from "./configSchema";
 import { NON_EDITABLE_FILE_HEADER } from "./constants";
@@ -101,6 +101,9 @@ const main = async () => {
 					config.locales.fetchFromRepository,
 			});
 
+			const typesProvider =
+				config.typesProvider || (await detectTypesProvider());
+
 			const hasCustomTypeModels = customTypeModels.length > 0;
 
 			if (
@@ -124,6 +127,7 @@ const main = async () => {
 					includeContentNamespace:
 						config.clientIntegration?.includeContentNamespace ?? true,
 				},
+				typesProvider,
 			});
 
 			const fileContents = `${NON_EDITABLE_FILE_HEADER}\n\n${types}`;

--- a/src/cli/loadModels.ts
+++ b/src/cli/loadModels.ts
@@ -1,9 +1,8 @@
 import * as prismicCT from "@prismicio/custom-types-client";
+import type { CustomTypeModel, SharedSliceModel } from "@prismicio/client";
 import fg from "fast-glob";
 import { readFileSync } from "fs";
 import fetch from "node-fetch";
-
-import type { CustomTypeModel, SharedSliceModel } from "@prismicio/types";
 
 const isCustomTypeModel = (input: unknown): input is CustomTypeModel => {
 	return typeof input === "object" && input !== null && "json" in input;

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,3 +1,5 @@
+import { TypesProvider } from "../generateTypes";
+
 /**
  * Configuration to control the generated types.
  */
@@ -25,6 +27,14 @@ export type Config = {
 	 * relative to where the command is called.
 	 */
 	output?: string;
+
+	/**
+	 * The package that provides TypeScript types for Prismic data. Most projects
+	 * will not need to configure this option.
+	 *
+	 * @defaultValue Automatically detected using the project's `package.json`.
+	 */
+	typesProvider?: TypesProvider;
 
 	/**
 	 * Configuration for automatic `@prismicio/client` integration.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import type { CustomTypeModelFieldType } from "@prismicio/types";
+import type { CustomTypeModelFieldType } from "@prismicio/client";
 
 export const BLANK_LINE_IDENTIFIER = "// ___BLANK_LINE_TO_BE_REPLACED___";
 
@@ -9,7 +9,10 @@ export const SHARED_SLICES_DOCUMENTATION_URL =
 	"https://prismic.io/docs/core-concepts/reusing-slices";
 
 export const FIELD_DOCUMENTATION_URLS: Record<
-	Exclude<keyof typeof CustomTypeModelFieldType, "Range" | "Separator">,
+	Exclude<
+		(typeof CustomTypeModelFieldType)[keyof typeof CustomTypeModelFieldType],
+		"Range" | "Separator"
+	>,
 	string
 > = {
 	UID: "https://prismic.io/docs/core-concepts/uid",
@@ -28,5 +31,5 @@ export const FIELD_DOCUMENTATION_URLS: Record<
 	Group: "https://prismic.io/docs/core-concepts/group",
 	IntegrationFields: "https://prismic.io/docs/core-concepts/integration-fields",
 	Slices: "https://prismic.io/docs/core-concepts/slices",
-	LegacySlices: "https://prismic.io/docs/core-concepts/slices",
+	Choice: "https://prismic.io/docs/core-concepts/slices",
 };

--- a/src/detectTypesProvider.ts
+++ b/src/detectTypesProvider.ts
@@ -1,0 +1,32 @@
+import { createRequire } from "node:module";
+
+import { TypesProvider } from "./generateTypes";
+
+export type DetectTypesProviderConfig = {
+	cwd?: string;
+};
+
+/**
+ * Detects which types provider should be used for a project.
+ *
+ * @param config - Configures the detection.
+ *
+ * @returns The types provider identifier to use, or `undefined` if on cannot be
+ *   determined.
+ */
+export const detectTypesProvider = async (
+	config: DetectTypesProviderConfig = {},
+): Promise<TypesProvider | undefined> => {
+	const require = createRequire(config.cwd || process.cwd());
+
+	if (
+		// Only @prismicio/client >= v7 exports types.
+		Number.parseInt(
+			require("@prismicio/client/package.json").version.split(".")[0],
+		) >= 7
+	) {
+		return "@prismicio/client";
+	} else if (require.resolve("@prismicio/types")) {
+		return "@prismicio/types";
+	}
+};

--- a/src/generateTypes.ts
+++ b/src/generateTypes.ts
@@ -32,7 +32,7 @@ export const generateTypes = (config: GenerateTypesConfig = {}) => {
 	const sourceFile = project.createSourceFile("types.d.ts");
 
 	sourceFile.addImportDeclaration({
-		moduleSpecifier: config.typesProvider || "@prismicio/client",
+		moduleSpecifier: config.typesProvider || "@prismicio/types",
 		namespaceImport: "prismic",
 		isTypeOnly: true,
 	});

--- a/src/generateTypes.ts
+++ b/src/generateTypes.ts
@@ -1,3 +1,4 @@
+import type { CustomTypeModel, SharedSliceModel } from "@prismicio/client";
 import { ModuleDeclarationKind, Project } from "ts-morph";
 
 import { addTypeAliasForCustomType } from "./lib/addTypeAliasForCustomType";
@@ -6,15 +7,17 @@ import { buildTypeName } from "./lib/buildTypeName";
 import { getSourceFileText } from "./lib/getSourceFileText";
 
 import { FieldConfigs } from "./types";
-import type { CustomTypeModel, SharedSliceModel } from "@prismicio/types";
 
 import { BLANK_LINE_IDENTIFIER } from "./constants";
+
+export type TypesProvider = "@prismicio/client" | "@prismicio/types";
 
 export type GenerateTypesConfig = {
 	customTypeModels?: CustomTypeModel[];
 	sharedSliceModels?: SharedSliceModel[];
 	localeIDs?: string[];
 	fieldConfigs?: FieldConfigs;
+	typesProvider?: TypesProvider;
 	clientIntegration?: {
 		includeCreateClientInterface?: boolean;
 		includeContentNamespace?: boolean;
@@ -29,8 +32,8 @@ export const generateTypes = (config: GenerateTypesConfig = {}) => {
 	const sourceFile = project.createSourceFile("types.d.ts");
 
 	sourceFile.addImportDeclaration({
-		moduleSpecifier: "@prismicio/types",
-		namespaceImport: "prismicT",
+		moduleSpecifier: config.typesProvider || "@prismicio/client",
+		namespaceImport: "prismic",
 		isTypeOnly: true,
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 export { generateTypes } from "./generateTypes";
-export type { GenerateTypesConfig } from "./generateTypes";
+export type { GenerateTypesConfig, TypesProvider } from "./generateTypes";
+
+export { detectTypesProvider } from "./detectTypesProvider";
+export type { DetectTypesProviderConfig } from "./detectTypesProvider";
 
 // The CLI configuration type is exported at the root level for ease of access.
 // It is not used in the the library's code.

--- a/src/lib/addInterfacePropertiesForFields.ts
+++ b/src/lib/addInterfacePropertiesForFields.ts
@@ -1,16 +1,16 @@
-import type { InterfaceDeclaration, SourceFile } from "ts-morph";
-
-import { FieldConfigs, PathElement } from "../types";
 import type {
 	CustomTypeModel,
 	CustomTypeModelField,
 	CustomTypeModelSlice,
 	SharedSliceModel,
-} from "@prismicio/types";
+} from "@prismicio/client";
 import {
 	CustomTypeModelLinkSelectType,
 	CustomTypeModelSliceType,
-} from "@prismicio/types";
+} from "@prismicio/client";
+import type { InterfaceDeclaration, SourceFile } from "ts-morph";
+
+import { FieldConfigs, PathElement } from "../types";
 
 import { buildFieldDocs } from "./buildFieldDocs";
 import { buildSharedSliceInterfaceNamePart } from "./buildSharedSliceInterfaceNamePart";
@@ -42,7 +42,7 @@ const addInterfacePropertyForField = (
 		case "Boolean": {
 			config.interface.addProperty({
 				name: config.id,
-				type: "prismicT.BooleanField",
+				type: "prismic.BooleanField",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -57,7 +57,7 @@ const addInterfacePropertyForField = (
 		case "Color": {
 			config.interface.addProperty({
 				name: config.id,
-				type: "prismicT.ColorField",
+				type: "prismic.ColorField",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -72,7 +72,7 @@ const addInterfacePropertyForField = (
 		case "Date": {
 			config.interface.addProperty({
 				name: config.id,
-				type: "prismicT.DateField",
+				type: "prismic.DateField",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -102,10 +102,10 @@ const addInterfacePropertyForField = (
 				name: config.id,
 				type:
 					providerTypes.length > 0
-						? `prismicT.EmbedField<prismicT.AnyOEmbed & prismicT.OEmbedExtra & (${providerTypes.join(
+						? `prismic.EmbedField<prismic.AnyOEmbed & prismic.OEmbedExtra & (${providerTypes.join(
 								" | ",
 						  )})>`
-						: "prismicT.EmbedField",
+						: "prismic.EmbedField",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -120,7 +120,7 @@ const addInterfacePropertyForField = (
 		case "GeoPoint": {
 			config.interface.addProperty({
 				name: config.id,
-				type: "prismicT.GeoPointField",
+				type: "prismic.GeoPointField",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -143,7 +143,7 @@ const addInterfacePropertyForField = (
 
 				config.interface.addProperty({
 					name: config.id,
-					type: `prismicT.ImageField<${thumbnailNames}>`,
+					type: `prismic.ImageField<${thumbnailNames}>`,
 					docs: buildFieldDocs({
 						id: config.id,
 						model: config.model,
@@ -154,7 +154,7 @@ const addInterfacePropertyForField = (
 			} else {
 				config.interface.addProperty({
 					name: config.id,
-					type: "prismicT.ImageField<never>",
+					type: "prismic.ImageField<never>",
 					docs: buildFieldDocs({
 						id: config.id,
 						model: config.model,
@@ -177,8 +177,8 @@ const addInterfacePropertyForField = (
 			config.interface.addProperty({
 				name: config.id,
 				type: catalogType
-					? `prismicT.IntegrationFields<${catalogType}>`
-					: "prismicT.IntegrationFields",
+					? `prismic.IntegrationFields<${catalogType}>`
+					: "prismic.IntegrationFields",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -200,10 +200,10 @@ const addInterfacePropertyForField = (
 							"customtypes" in config.model.config &&
 							config.model.config.customtypes &&
 							config.model.config.customtypes.length > 0
-								? `prismicT.RelationField<${config.model.config.customtypes
+								? `prismic.RelationField<${config.model.config.customtypes
 										.map((type) => `"${type}"`)
 										.join(" | ")}>`
-								: "prismicT.RelationField",
+								: "prismic.RelationField",
 						docs: buildFieldDocs({
 							id: config.id,
 							model: config.model,
@@ -218,7 +218,7 @@ const addInterfacePropertyForField = (
 				case CustomTypeModelLinkSelectType.Media: {
 					config.interface.addProperty({
 						name: config.id,
-						type: "prismicT.LinkToMediaField",
+						type: "prismic.LinkToMediaField",
 						docs: buildFieldDocs({
 							id: config.id,
 							model: config.model,
@@ -233,7 +233,7 @@ const addInterfacePropertyForField = (
 				default: {
 					config.interface.addProperty({
 						name: config.id,
-						type: "prismicT.LinkField",
+						type: "prismic.LinkField",
 						docs: buildFieldDocs({
 							id: config.id,
 							model: config.model,
@@ -250,7 +250,7 @@ const addInterfacePropertyForField = (
 		case "Number": {
 			config.interface.addProperty({
 				name: config.id,
-				type: "prismicT.NumberField",
+				type: "prismic.NumberField",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -274,7 +274,7 @@ const addInterfacePropertyForField = (
 			if (isTitleField) {
 				config.interface.addProperty({
 					name: config.id,
-					type: "prismicT.TitleField",
+					type: "prismic.TitleField",
 					docs: buildFieldDocs({
 						id: config.id,
 						model: config.model,
@@ -285,7 +285,7 @@ const addInterfacePropertyForField = (
 			} else {
 				config.interface.addProperty({
 					name: config.id,
-					type: "prismicT.RichTextField",
+					type: "prismic.RichTextField",
 					docs: buildFieldDocs({
 						id: config.id,
 						model: config.model,
@@ -307,7 +307,7 @@ const addInterfacePropertyForField = (
 			if (hasDefault) {
 				config.interface.addProperty({
 					name: config.id,
-					type: `prismicT.SelectField<${options || "string"}, "filled">`,
+					type: `prismic.SelectField<${options || "string"}, "filled">`,
 					docs: buildFieldDocs({
 						id: config.id,
 						model: config.model,
@@ -318,7 +318,7 @@ const addInterfacePropertyForField = (
 			} else {
 				config.interface.addProperty({
 					name: config.id,
-					type: `prismicT.SelectField<${options}>`,
+					type: `prismic.SelectField<${options}>`,
 					docs: buildFieldDocs({
 						id: config.id,
 						model: config.model,
@@ -334,7 +334,7 @@ const addInterfacePropertyForField = (
 		case "Text": {
 			config.interface.addProperty({
 				name: config.id,
-				type: "prismicT.KeyTextField",
+				type: "prismic.KeyTextField",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -349,7 +349,7 @@ const addInterfacePropertyForField = (
 		case "Timestamp": {
 			config.interface.addProperty({
 				name: config.id,
-				type: "prismicT.TimestampField",
+				type: "prismic.TimestampField",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -408,7 +408,7 @@ const addInterfacePropertyForField = (
 
 			config.interface.addProperty({
 				name: config.id,
-				type: `prismicT.GroupField<Simplify<${itemInterface.getName()}>>`,
+				type: `prismic.GroupField<Simplify<${itemInterface.getName()}>>`,
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,
@@ -569,7 +569,7 @@ const addInterfacePropertyForField = (
 								choiceId,
 								"Slice",
 							),
-							type: `prismicT.Slice<"${choiceId}", ${
+							type: `prismic.Slice<"${choiceId}", ${
 								primaryInterface
 									? `Simplify<${primaryInterface.getName()}>`
 									: "Record<string, never>"
@@ -617,7 +617,7 @@ const addInterfacePropertyForField = (
 
 			config.interface.addProperty({
 				name: config.id,
-				type: `prismicT.SliceZone<${slicesType.getName()}>`,
+				type: `prismic.SliceZone<${slicesType.getName()}>`,
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,

--- a/src/lib/addTypeAliasForCustomType.ts
+++ b/src/lib/addTypeAliasForCustomType.ts
@@ -1,3 +1,4 @@
+import type { CustomTypeModel, CustomTypeModelField } from "@prismicio/client";
 import type {
 	InterfaceDeclaration,
 	SourceFile,
@@ -5,7 +6,6 @@ import type {
 } from "ts-morph";
 
 import { FieldConfigs } from "../types";
-import type { CustomTypeModel, CustomTypeModelField } from "@prismicio/types";
 
 import { CUSTOM_TYPES_DOCUMENTATION_URL } from "../constants";
 
@@ -90,10 +90,10 @@ export const addTypeAliasForCustomType = ({
 			},
 		],
 		type: hasUIDField
-			? `prismicT.PrismicDocumentWithUID<Simplify<${dataInterface.getName()}>, "${
+			? `prismic.PrismicDocumentWithUID<Simplify<${dataInterface.getName()}>, "${
 					model.id
 			  }", Lang>`
-			: `prismicT.PrismicDocumentWithoutUID<Simplify<${dataInterface.getName()}>, "${
+			: `prismic.PrismicDocumentWithoutUID<Simplify<${dataInterface.getName()}>, "${
 					model.id
 			  }", Lang>`,
 		docs: [

--- a/src/lib/addTypeAliasForSharedSlice.ts
+++ b/src/lib/addTypeAliasForSharedSlice.ts
@@ -1,3 +1,4 @@
+import type { SharedSliceModel } from "@prismicio/client";
 import type {
 	InterfaceDeclaration,
 	SourceFile,
@@ -5,7 +6,6 @@ import type {
 } from "ts-morph";
 
 import { FieldConfigs } from "../types";
-import type { SharedSliceModel } from "@prismicio/types";
 
 import { SHARED_SLICES_DOCUMENTATION_URL } from "../constants";
 
@@ -126,7 +126,7 @@ export const addTypeAliasForSharedSlice = (
 				buildSharedSliceInterfaceNamePart({ id: config.model.id }),
 				variation.id,
 			),
-			type: `prismicT.SharedSliceVariation<"${variation.id}", ${
+			type: `prismic.SharedSliceVariation<"${variation.id}", ${
 				primaryInterface
 					? `Simplify<${primaryInterface.getName()}>`
 					: "Record<string, never>"
@@ -178,7 +178,7 @@ export const addTypeAliasForSharedSlice = (
 		name: buildTypeName(
 			buildSharedSliceInterfaceNamePart({ id: config.model.id }),
 		),
-		type: `prismicT.SharedSlice<"${
+		type: `prismic.SharedSlice<"${
 			config.model.id
 		}", ${variationsType.getName()}>`,
 		docs: [

--- a/src/lib/buildFieldDocs.ts
+++ b/src/lib/buildFieldDocs.ts
@@ -1,12 +1,12 @@
-import type { JSDocableNodeStructure } from "ts-morph";
-
-import { PathElement } from "../types";
 import type {
 	CustomTypeModel,
 	CustomTypeModelField,
 	CustomTypeModelSlice,
 	SharedSliceModel,
-} from "@prismicio/types";
+} from "@prismicio/client";
+import type { JSDocableNodeStructure } from "ts-morph";
+
+import { PathElement } from "../types";
 
 import { getAPIIDPath } from "./getAPIIDPath";
 import { getFieldDocumentationURL } from "./getFieldDocumentationURL";

--- a/src/lib/getAPIIDPath.ts
+++ b/src/lib/getAPIIDPath.ts
@@ -1,11 +1,12 @@
-import { PathElement } from "../types";
 import type {
 	CustomTypeModel,
 	CustomTypeModelField,
 	CustomTypeModelSlice,
 	SharedSliceModel,
-} from "@prismicio/types";
-import { CustomTypeModelFieldType } from "@prismicio/types";
+} from "@prismicio/client";
+import { CustomTypeModelFieldType } from "@prismicio/client";
+
+import { PathElement } from "../types";
 
 import { isCustomTypeModelField } from "./isCustomTypeModelField";
 import { isCustomTypeModelSlice } from "./isCustomTypeModelSlice";

--- a/src/lib/getFieldDocumentationURL.ts
+++ b/src/lib/getFieldDocumentationURL.ts
@@ -1,4 +1,4 @@
-import type { CustomTypeModelField } from "@prismicio/types";
+import type { CustomTypeModelField } from "@prismicio/client";
 
 import { FIELD_DOCUMENTATION_URLS } from "../constants";
 

--- a/src/lib/getHumanReadableFieldPath.ts
+++ b/src/lib/getHumanReadableFieldPath.ts
@@ -1,10 +1,11 @@
-import { PathElement } from "../types";
 import type {
 	CustomTypeModel,
 	CustomTypeModelField,
 	CustomTypeModelSlice,
 	SharedSliceModel,
-} from "@prismicio/types";
+} from "@prismicio/client";
+
+import { PathElement } from "../types";
 
 import { getHumanReadableModelName } from "./getHumanReadableModelName";
 

--- a/src/lib/getHumanReadableFieldType.ts
+++ b/src/lib/getHumanReadableFieldType.ts
@@ -1,5 +1,5 @@
-import type { CustomTypeModelField } from "@prismicio/types";
-import { CustomTypeModelLinkSelectType } from "@prismicio/types";
+import type { CustomTypeModelField } from "@prismicio/client";
+import { CustomTypeModelLinkSelectType } from "@prismicio/client";
 
 type GetFieldHumanReadableTypeConfig = {
 	model: CustomTypeModelField;

--- a/src/lib/getHumanReadableModelName.ts
+++ b/src/lib/getHumanReadableModelName.ts
@@ -3,7 +3,7 @@ import type {
 	CustomTypeModelField,
 	CustomTypeModelSlice,
 	SharedSliceModel,
-} from "@prismicio/types";
+} from "@prismicio/client";
 
 import { isCustomTypeModel } from "./isCustomTypeModel";
 import { isCustomTypeModelField } from "./isCustomTypeModelField";

--- a/src/lib/isCustomTypeModel.ts
+++ b/src/lib/isCustomTypeModel.ts
@@ -1,4 +1,4 @@
-import type { CustomTypeModel } from "@prismicio/types";
+import type { CustomTypeModel } from "@prismicio/client";
 
 export const isCustomTypeModel = (model: unknown): model is CustomTypeModel => {
 	return typeof model === "object" && model !== null && "json" in model;

--- a/src/lib/isCustomTypeModelField.ts
+++ b/src/lib/isCustomTypeModelField.ts
@@ -1,4 +1,4 @@
-import type { CustomTypeModelField } from "@prismicio/types";
+import type { CustomTypeModelField } from "@prismicio/client";
 
 export const isCustomTypeModelField = (
 	model: unknown,

--- a/src/lib/isCustomTypeModelSlice.ts
+++ b/src/lib/isCustomTypeModelSlice.ts
@@ -1,7 +1,7 @@
 import {
 	CustomTypeModelSlice,
 	CustomTypeModelSliceType,
-} from "@prismicio/types";
+} from "@prismicio/client";
 
 import { hasOwnProperty } from "./hasOwnProperty";
 

--- a/src/lib/isSharedSliceModel.ts
+++ b/src/lib/isSharedSliceModel.ts
@@ -1,4 +1,4 @@
-import { CustomTypeModelSliceType, SharedSliceModel } from "@prismicio/types";
+import { CustomTypeModelSliceType, SharedSliceModel } from "@prismicio/client";
 
 import { hasOwnProperty } from "./hasOwnProperty";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type {
 	CustomTypeModelField,
 	CustomTypeModelSlice,
 	SharedSliceModel,
-} from "@prismicio/types";
+} from "@prismicio/client";
 
 export type PathElement<
 	Model extends

--- a/test/__testutils__/expectToHaveDocs.ts
+++ b/test/__testutils__/expectToHaveDocs.ts
@@ -1,5 +1,5 @@
-import * as prismicT from "@prismicio/types";
+import * as prismic from "@prismicio/client";
 
-export function expectToHaveDocs(_model: prismicT.CustomTypeModelField) {
+export function expectToHaveDocs(_model: prismic.CustomTypeModelField) {
 	// TODO
 }

--- a/test/__testutils__/expectToHaveFieldType.ts
+++ b/test/__testutils__/expectToHaveFieldType.ts
@@ -1,15 +1,14 @@
 import { expect } from "vitest";
 
+import * as prismic from "@prismicio/client";
 import * as prismicM from "@prismicio/mock";
-
-import * as prismicT from "@prismicio/types";
 
 import { parseSourceFile } from "./parseSourceFile";
 
 import * as lib from "../../src";
 
 export function expectToHaveFieldType(
-	model: prismicT.CustomTypeModelField,
+	model: prismic.CustomTypeModelField,
 	expectedFieldType: string,
 ) {
 	const res = lib.generateTypes({

--- a/test/generateTypes-boolean.test.ts
+++ b/test/generateTypes-boolean.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.boolean(), "prismicT.BooleanField");
+	expectToHaveFieldType(ctx.mock.model.boolean(), "prismic.BooleanField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-color.test.ts
+++ b/test/generateTypes-color.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.color(), "prismicT.ColorField");
+	expectToHaveFieldType(ctx.mock.model.color(), "prismic.ColorField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-contentRelationship.test.ts
+++ b/test/generateTypes-contentRelationship.test.ts
@@ -6,7 +6,7 @@ import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 it("is correctly typed", (ctx) => {
 	const model = ctx.mock.model.contentRelationship();
 
-	expectToHaveFieldType(model, "prismicT.RelationField");
+	expectToHaveFieldType(model, "prismic.RelationField");
 });
 
 it("is correctly typed", (ctx) => {
@@ -14,7 +14,7 @@ it("is correctly typed", (ctx) => {
 		customTypeIDs: ["foo", "bar"],
 	});
 
-	expectToHaveFieldType(model, 'prismicT.RelationField<"foo" | "bar">');
+	expectToHaveFieldType(model, 'prismic.RelationField<"foo" | "bar">');
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-customType.test.ts
+++ b/test/generateTypes-customType.test.ts
@@ -29,7 +29,7 @@ it("generates a Custom Type type", (ctx) => {
 
 	const type = typeAlias.getTypeNodeOrThrow();
 	expect(type.getText()).toBe(
-		'prismicT.PrismicDocumentWithoutUID<Simplify<FooDocumentData>, "foo", Lang>',
+		'prismic.PrismicDocumentWithoutUID<Simplify<FooDocumentData>, "foo", Lang>',
 	);
 
 	expect(() => {
@@ -52,7 +52,7 @@ it("uses PrismicDocumentWithUID when model contains a UID field", (ctx) => {
 	const file = parseSourceFile(res);
 	const type = file.getTypeAliasOrThrow("FooDocument").getTypeNodeOrThrow();
 	expect(type.getText()).toBe(
-		'prismicT.PrismicDocumentWithUID<Simplify<FooDocumentData>, "foo", Lang>',
+		'prismic.PrismicDocumentWithUID<Simplify<FooDocumentData>, "foo", Lang>',
 	);
 });
 
@@ -147,7 +147,7 @@ it("handles hyphenated fields", (ctx) => {
 			.getPropertyOrThrow('"hyphenated-field"')
 			.getTypeNodeOrThrow()
 			.getText(),
-	).toBe("prismicT.KeyTextField");
+	).toBe("prismic.KeyTextField");
 });
 
 it("handles fields starting with a number", (ctx) => {
@@ -170,7 +170,7 @@ it("handles fields starting with a number", (ctx) => {
 			.getPropertyOrThrow('"3d_noodle"')
 			.getTypeNodeOrThrow()
 			.getText(),
-	).toBe("prismicT.KeyTextField");
+	).toBe("prismic.KeyTextField");
 });
 
 it("prefixes types starting with a number with an underscore", (ctx) => {

--- a/test/generateTypes-date.test.ts
+++ b/test/generateTypes-date.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.date(), "prismicT.DateField");
+	expectToHaveFieldType(ctx.mock.model.date(), "prismic.DateField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-embed.test.ts
+++ b/test/generateTypes-embed.test.ts
@@ -9,7 +9,7 @@ import { parseSourceFile } from "./__testutils__/parseSourceFile";
 import * as lib from "../src";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.embed(), "prismicT.EmbedField");
+	expectToHaveFieldType(ctx.mock.model.embed(), "prismic.EmbedField");
 });
 
 it("can be customized with provider-specific types", (ctx) => {
@@ -40,7 +40,7 @@ it("can be customized with provider-specific types", (ctx) => {
 		property.getTypeNodeOrThrow().getText({ trimLeadingIndentation: true }),
 	).toBe(
 		stripIndent`
-			prismicT.EmbedField<prismicT.AnyOEmbed & prismicT.OEmbedExtra & (({
+			prismic.EmbedField<prismic.AnyOEmbed & prismic.OEmbedExtra & (({
 			    provider_name: "YouTube";
 			} & YouTubeType) | ({
 			    provider_name: "Vimeo";

--- a/test/generateTypes-geoPoint.test.ts
+++ b/test/generateTypes-geoPoint.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.geoPoint(), "prismicT.GeoPointField");
+	expectToHaveFieldType(ctx.mock.model.geoPoint(), "prismic.GeoPointField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-group.test.ts
+++ b/test/generateTypes-group.test.ts
@@ -25,7 +25,7 @@ it("correctly typed", (ctx) => {
 		.getPropertyOrThrow("bar");
 
 	expect(groupProperty.getTypeNodeOrThrow().getText()).toBe(
-		"prismicT.GroupField<Simplify<FooDocumentDataBarItem>>",
+		"prismic.GroupField<Simplify<FooDocumentDataBarItem>>",
 	);
 });
 
@@ -50,10 +50,10 @@ it("creates an interface for a group item containing its fields", (ctx) => {
 
 	expect(
 		itemInterface.getPropertyOrThrow("baz").getTypeNodeOrThrow().getText(),
-	).toBe("prismicT.KeyTextField");
+	).toBe("prismic.KeyTextField");
 	expect(
 		itemInterface.getPropertyOrThrow("qux").getTypeNodeOrThrow().getText(),
-	).toBe("prismicT.SelectField");
+	).toBe("prismic.SelectField");
 });
 
 it("prefixes Group types starting with a number using an underscore prefix", (ctx) => {
@@ -76,7 +76,7 @@ it("prefixes Group types starting with a number using an underscore prefix", (ct
 		.getPropertyOrThrow('"456"');
 
 	expect(groupProperty.getTypeNodeOrThrow().getText()).toBe(
-		"prismicT.GroupField<Simplify<_123DocumentData456Item>>",
+		"prismic.GroupField<Simplify<_123DocumentData456Item>>",
 	);
 });
 
@@ -101,7 +101,7 @@ it("handles hyphenated fields", (ctx) => {
 			.getPropertyOrThrow('"hyphenated-field"')
 			.getTypeNodeOrThrow()
 			.getText(),
-	).toBe("prismicT.KeyTextField");
+	).toBe("prismic.KeyTextField");
 });
 
 it.todo("is correctly documented", (ctx) => {

--- a/test/generateTypes-image.test.ts
+++ b/test/generateTypes-image.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.image(), "prismicT.ImageField<never>");
+	expectToHaveFieldType(ctx.mock.model.image(), "prismic.ImageField<never>");
 });
 
 it("is correctly typed", (ctx) => {
@@ -12,7 +12,7 @@ it("is correctly typed", (ctx) => {
 		ctx.mock.model.image({
 			thumbnailNames: ["foo", "bar"],
 		}),
-		'prismicT.ImageField<"foo" | "bar">',
+		'prismic.ImageField<"foo" | "bar">',
 	);
 });
 

--- a/test/generateTypes-integrationFields.test.ts
+++ b/test/generateTypes-integrationFields.test.ts
@@ -9,7 +9,7 @@ import * as lib from "../src";
 it("is correctly typed", (ctx) => {
 	expectToHaveFieldType(
 		ctx.mock.model.integrationFields(),
-		"prismicT.IntegrationFields",
+		"prismic.IntegrationFields",
 	);
 });
 
@@ -38,10 +38,10 @@ it("can be customized with catalog-specific types", (ctx) => {
 
 	expect(
 		dataInterface.getPropertyOrThrow("bar").getTypeNodeOrThrow().getText(),
-	).toBe("prismicT.IntegrationFields<AbcType>");
+	).toBe("prismic.IntegrationFields<AbcType>");
 	expect(
 		dataInterface.getPropertyOrThrow("baz").getTypeNodeOrThrow().getText(),
-	).toBe("prismicT.IntegrationFields<DefType>");
+	).toBe("prismic.IntegrationFields<DefType>");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-keyText.test.ts
+++ b/test/generateTypes-keyText.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.keyText(), "prismicT.KeyTextField");
+	expectToHaveFieldType(ctx.mock.model.keyText(), "prismic.KeyTextField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-link.test.ts
+++ b/test/generateTypes-link.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.link(), "prismicT.LinkField");
+	expectToHaveFieldType(ctx.mock.model.link(), "prismic.LinkField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-linkToMedia.test.ts
+++ b/test/generateTypes-linkToMedia.test.ts
@@ -6,7 +6,7 @@ import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 it("is correctly typed", (ctx) => {
 	expectToHaveFieldType(
 		ctx.mock.model.linkToMedia(),
-		"prismicT.LinkToMediaField",
+		"prismic.LinkToMediaField",
 	);
 });
 

--- a/test/generateTypes-number.test.ts
+++ b/test/generateTypes-number.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.number(), "prismicT.NumberField");
+	expectToHaveFieldType(ctx.mock.model.number(), "prismic.NumberField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-richText.test.ts
+++ b/test/generateTypes-richText.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.richText(), "prismicT.RichTextField");
+	expectToHaveFieldType(ctx.mock.model.richText(), "prismic.RichTextField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-select.test.ts
+++ b/test/generateTypes-select.test.ts
@@ -8,7 +8,7 @@ it("is correctly typed", (ctx) => {
 		ctx.mock.model.select({
 			options: ["foo", "bar"],
 		}),
-		'prismicT.SelectField<"foo" | "bar">',
+		'prismic.SelectField<"foo" | "bar">',
 	);
 });
 
@@ -18,7 +18,7 @@ it("is always filled if a default value is defined in the model", (ctx) => {
 			options: ["foo", "bar"],
 			defaultValue: "bar",
 		}),
-		'prismicT.SelectField<"foo" | "bar", "filled">',
+		'prismic.SelectField<"foo" | "bar", "filled">',
 	);
 });
 

--- a/test/generateTypes-sharedSlice.test.ts
+++ b/test/generateTypes-sharedSlice.test.ts
@@ -36,7 +36,7 @@ it("correctly typed", (ctx) => {
 	expect(sliceTypeAlias.isExported()).toBe(true);
 
 	expect(sliceTypeAlias.getTypeNodeOrThrow().getText()).toBe(
-		'prismicT.SharedSlice<"foo", FooSliceVariation>',
+		'prismic.SharedSlice<"foo", FooSliceVariation>',
 	);
 });
 
@@ -109,11 +109,11 @@ it("creates a type alias for each Slice variation", (ctx) => {
 	expect(bazType.isExported()).toBe(true);
 
 	expect(barType.getTypeNodeOrThrow().getText()).toBe(
-		'prismicT.SharedSliceVariation<"bar", Simplify<FooSliceBarPrimary>, Simplify<FooSliceBarItem>>',
+		'prismic.SharedSliceVariation<"bar", Simplify<FooSliceBarPrimary>, Simplify<FooSliceBarItem>>',
 	);
 
 	expect(bazType.getTypeNodeOrThrow().getText()).toBe(
-		'prismicT.SharedSliceVariation<"baz", Simplify<FooSliceBazPrimary>, Simplify<FooSliceBazItem>>',
+		'prismic.SharedSliceVariation<"baz", Simplify<FooSliceBazPrimary>, Simplify<FooSliceBazItem>>',
 	);
 });
 
@@ -128,7 +128,7 @@ it("handles Slice variations with no fields", (ctx) => {
 
 	expect(
 		file.getTypeAliasOrThrow("FooSliceBar").getTypeNodeOrThrow().getText(),
-	).toBe('prismicT.SharedSliceVariation<"bar", Record<string, never>, never>');
+	).toBe('prismic.SharedSliceVariation<"bar", Record<string, never>, never>');
 });
 
 it("handles Slice variations with no primary fields", (ctx) => {
@@ -150,7 +150,7 @@ it("handles Slice variations with no primary fields", (ctx) => {
 	expect(
 		file.getTypeAliasOrThrow("FooSliceBar").getTypeNodeOrThrow().getText(),
 	).toBe(
-		'prismicT.SharedSliceVariation<"bar", Record<string, never>, Simplify<FooSliceBarItem>>',
+		'prismic.SharedSliceVariation<"bar", Record<string, never>, Simplify<FooSliceBarItem>>',
 	);
 });
 
@@ -173,7 +173,7 @@ it("handles Slice variations with no item fields", (ctx) => {
 	expect(
 		file.getTypeAliasOrThrow("FooSliceBar").getTypeNodeOrThrow().getText(),
 	).toBe(
-		'prismicT.SharedSliceVariation<"bar", Simplify<FooSliceBarPrimary>, never>',
+		'prismic.SharedSliceVariation<"bar", Simplify<FooSliceBarPrimary>, never>',
 	);
 });
 
@@ -199,7 +199,7 @@ it("creates an interface for a Slice variation's primary fields", (ctx) => {
 	const primaryInterface = file.getInterfaceOrThrow("FooSliceBarPrimary");
 	expect(
 		primaryInterface.getPropertyOrThrow("abc").getTypeNodeOrThrow().getText(),
-	).toBe("prismicT.KeyTextField");
+	).toBe("prismic.KeyTextField");
 });
 
 it("creates an interface for a Slice variation's items fields", (ctx) => {
@@ -227,7 +227,7 @@ it("creates an interface for a Slice variation's items fields", (ctx) => {
 
 	expect(
 		itemInterface.getPropertyOrThrow("def").getTypeNodeOrThrow().getText(),
-	).toBe("prismicT.SelectField");
+	).toBe("prismic.SelectField");
 });
 
 it("handles Shared Slice with no variations", (ctx) => {
@@ -241,7 +241,7 @@ it("handles Shared Slice with no variations", (ctx) => {
 
 	expect(
 		file.getTypeAliasOrThrow("FooSlice").getTypeNodeOrThrow().getText(),
-	).toBe('prismicT.SharedSlice<"foo", FooSliceVariation>');
+	).toBe('prismic.SharedSlice<"foo", FooSliceVariation>');
 
 	expect(
 		file
@@ -278,14 +278,14 @@ it("handles hyphenated fields", (ctx) => {
 			.getPropertyOrThrow('"hyphenated-field"')
 			.getTypeNodeOrThrow()
 			.getText(),
-	).toBe("prismicT.KeyTextField");
+	).toBe("prismic.KeyTextField");
 
 	expect(
 		itemInterface
 			.getPropertyOrThrow('"hyphenated-field"')
 			.getTypeNodeOrThrow()
 			.getText(),
-	).toBe("prismicT.SelectField");
+	).toBe("prismic.SelectField");
 });
 
 it("prefixes types starting with a number with an underscore", (ctx) => {
@@ -315,7 +315,7 @@ it("prefixes types starting with a number with an underscore", (ctx) => {
 		file.getTypeAliasOrThrow("_123SliceVariation");
 
 	expect(sliceTypeAlias.getTypeNodeOrThrow().getText()).toBe(
-		'prismicT.SharedSlice<"123", _123SliceVariation>',
+		'prismic.SharedSlice<"123", _123SliceVariation>',
 	);
 
 	expect(sliceVariationTypeAlias.getTypeNodeOrThrow().getText()).toBe(

--- a/test/generateTypes-sliceZone.test.ts
+++ b/test/generateTypes-sliceZone.test.ts
@@ -38,7 +38,7 @@ it("correctly typed", (ctx) => {
 		.getPropertyOrThrow("bar");
 
 	expect(sliceZoneProperty.getTypeNodeOrThrow().getText()).toBe(
-		"prismicT.SliceZone<FooDocumentDataBarSlice>",
+		"prismic.SliceZone<FooDocumentDataBarSlice>",
 	);
 });
 
@@ -116,11 +116,11 @@ it("creates a type alias for each Slice", (ctx) => {
 	expect(quxSliceType.isExported()).toBe(true);
 
 	expect(bazSliceType.getTypeNodeOrThrow().getText()).toBe(
-		'prismicT.Slice<"baz", Simplify<FooDocumentDataBarBazSlicePrimary>, Simplify<FooDocumentDataBarBazSliceItem>>',
+		'prismic.Slice<"baz", Simplify<FooDocumentDataBarBazSlicePrimary>, Simplify<FooDocumentDataBarBazSliceItem>>',
 	);
 
 	expect(quxSliceType.getTypeNodeOrThrow().getText()).toBe(
-		'prismicT.Slice<"qux", Simplify<FooDocumentDataBarQuxSlicePrimary>, Simplify<FooDocumentDataBarQuxSliceItem>>',
+		'prismic.Slice<"qux", Simplify<FooDocumentDataBarQuxSlicePrimary>, Simplify<FooDocumentDataBarQuxSliceItem>>',
 	);
 });
 
@@ -144,7 +144,7 @@ it("handles Slices with no fields", (ctx) => {
 			.getTypeAliasOrThrow("FooDocumentDataBarBazSlice")
 			.getTypeNodeOrThrow()
 			.getText(),
-	).toBe('prismicT.Slice<"baz", Record<string, never>, never>');
+	).toBe('prismic.Slice<"baz", Record<string, never>, never>');
 });
 
 it("handles Slices with no primary fields", (ctx) => {
@@ -172,7 +172,7 @@ it("handles Slices with no primary fields", (ctx) => {
 			.getTypeNodeOrThrow()
 			.getText(),
 	).toBe(
-		'prismicT.Slice<"baz", Record<string, never>, Simplify<FooDocumentDataBarBazSliceItem>>',
+		'prismic.Slice<"baz", Record<string, never>, Simplify<FooDocumentDataBarBazSliceItem>>',
 	);
 });
 
@@ -201,7 +201,7 @@ it("handles Slices with no item fields", (ctx) => {
 			.getTypeNodeOrThrow()
 			.getText(),
 	).toBe(
-		'prismicT.Slice<"baz", Simplify<FooDocumentDataBarBazSlicePrimary>, never>',
+		'prismic.Slice<"baz", Simplify<FooDocumentDataBarBazSlicePrimary>, never>',
 	);
 });
 
@@ -232,7 +232,7 @@ it("creates an interface for a Slice's primary fields", (ctx) => {
 	);
 	expect(
 		primaryInterface.getPropertyOrThrow("abc").getTypeNodeOrThrow().getText(),
-	).toBe("prismicT.KeyTextField");
+	).toBe("prismic.KeyTextField");
 });
 
 it("creates an interface for a Slice's items fields", (ctx) => {
@@ -265,7 +265,7 @@ it("creates an interface for a Slice's items fields", (ctx) => {
 
 	expect(
 		itemInterface.getPropertyOrThrow("def").getTypeNodeOrThrow().getText(),
-	).toBe("prismicT.SelectField");
+	).toBe("prismic.SelectField");
 });
 
 it("handles hyphenated fields", (ctx) => {
@@ -302,14 +302,14 @@ it("handles hyphenated fields", (ctx) => {
 			.getPropertyOrThrow('"hyphenated-field"')
 			.getTypeNodeOrThrow()
 			.getText(),
-	).toBe("prismicT.KeyTextField");
+	).toBe("prismic.KeyTextField");
 
 	expect(
 		itemInterface
 			.getPropertyOrThrow('"hyphenated-field"')
 			.getTypeNodeOrThrow()
 			.getText(),
-	).toBe("prismicT.SelectField");
+	).toBe("prismic.SelectField");
 });
 
 it("prefixes types starting with a number with an underscore", (ctx) => {
@@ -341,7 +341,7 @@ it("prefixes types starting with a number with an underscore", (ctx) => {
 	const sliceType = file.getTypeAliasOrThrow("_123DocumentData456789Slice");
 
 	expect(sliceZoneProperty.getTypeNodeOrThrow().getText()).toBe(
-		"prismicT.SliceZone<_123DocumentData456Slice>",
+		"prismic.SliceZone<_123DocumentData456Slice>",
 	);
 
 	expect(sliceTypeAlias.getTypeNodeOrThrow().getText()).toBe(
@@ -352,6 +352,6 @@ it("prefixes types starting with a number with an underscore", (ctx) => {
 
 	expect(
 		sliceType.getTypeNodeOrThrow().getText(),
-		'prismicT.Slice<"789", Simplify<_123DocumentData456789SlicePrimary>, Simplify<_123DocumentData456789SliceItem>>',
+		'prismic.Slice<"789", Simplify<_123DocumentData456789SlicePrimary>, Simplify<_123DocumentData456789SliceItem>>',
 	);
 });

--- a/test/generateTypes-timestamp.test.ts
+++ b/test/generateTypes-timestamp.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.timestamp(), "prismicT.TimestampField");
+	expectToHaveFieldType(ctx.mock.model.timestamp(), "prismic.TimestampField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-title.test.ts
+++ b/test/generateTypes-title.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.title(), "prismicT.TitleField");
+	expectToHaveFieldType(ctx.mock.model.title(), "prismic.TitleField");
 });
 
 it("is correctly documented", (ctx) => {

--- a/test/generateTypes-unknown.test.ts
+++ b/test/generateTypes-unknown.test.ts
@@ -1,9 +1,9 @@
 import { it } from "vitest";
 
+import * as prismic from "@prismicio/client";
+
 import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
-
-import * as prismicT from "@prismicio/types";
 
 it("is correctly typed", () => {
 	expectToHaveFieldType(
@@ -13,7 +13,7 @@ it("is correctly typed", () => {
 			config: {
 				label: "Non-existant field type",
 			},
-		} as prismicT.CustomTypeModelField,
+		} as prismic.CustomTypeModelField,
 		"unknown",
 	);
 });
@@ -26,6 +26,6 @@ it("is correctly documented", () => {
 			config: {
 				label: "Non-existant field type",
 			},
-		} as prismicT.CustomTypeModelField,
+		} as prismic.CustomTypeModelField,
 	);
 });

--- a/test/generateTypes.test.ts
+++ b/test/generateTypes.test.ts
@@ -4,12 +4,12 @@ import { parseSourceFile } from "./__testutils__/parseSourceFile";
 
 import * as lib from "../src";
 
-it("imports @prismicio/client as prismic as the default types provider", () => {
+it("imports @prismicio/types as prismic as the default types provider", () => {
 	const res = lib.generateTypes();
 	const file = parseSourceFile(res);
 
 	const importDeclaration =
-		file.getImportDeclarationOrThrow("@prismicio/client");
+		file.getImportDeclarationOrThrow("@prismicio/types");
 
 	expect(importDeclaration.getNamespaceImportOrThrow().getText()).toBe(
 		"prismic",

--- a/test/generateTypes.test.ts
+++ b/test/generateTypes.test.ts
@@ -4,15 +4,41 @@ import { parseSourceFile } from "./__testutils__/parseSourceFile";
 
 import * as lib from "../src";
 
-it("imports @prismicio/types as prismicT", () => {
+it("imports @prismicio/client as prismic as the default types provider", () => {
 	const res = lib.generateTypes();
+	const file = parseSourceFile(res);
+
+	const importDeclaration =
+		file.getImportDeclarationOrThrow("@prismicio/client");
+
+	expect(importDeclaration.getNamespaceImportOrThrow().getText()).toBe(
+		"prismic",
+	);
+	expect(importDeclaration.isTypeOnly()).toBe(true);
+});
+
+it("imports @prismicio/client as prismic if the `@prismicio/client` types provider is used", () => {
+	const res = lib.generateTypes({ typesProvider: "@prismicio/client" });
+	const file = parseSourceFile(res);
+
+	const importDeclaration =
+		file.getImportDeclarationOrThrow("@prismicio/client");
+
+	expect(importDeclaration.getNamespaceImportOrThrow().getText()).toBe(
+		"prismic",
+	);
+	expect(importDeclaration.isTypeOnly()).toBe(true);
+});
+
+it("imports @prismicio/types as prismic if the `@prismicio/types` types provider is used", () => {
+	const res = lib.generateTypes({ typesProvider: "@prismicio/types" });
 	const file = parseSourceFile(res);
 
 	const importDeclaration =
 		file.getImportDeclarationOrThrow("@prismicio/types");
 
 	expect(importDeclaration.getNamespaceImportOrThrow().getText()).toBe(
-		"prismicT",
+		"prismic",
 	);
 	expect(importDeclaration.isTypeOnly()).toBe(true);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR allows `prismic-ts-codegen` to use different type providers. The following providers are supported:

- `@prismicio/client` (at least v7)
- `@prismicio/types` - default

`@prismicio/types` is used by default for backwards compatibility, but `@prismicio/client` is preferred since `@prismicio/types` is now deprecated. `@prismicio/types` was merged into `@prismicio/client` v7.

This PR also adds a `detectTypesProvider()` helper. See below for more details.

### `prismic-ts-codegen` CLI

The `prismic-ts-codegen` CLI can be configured using a `prismicCodegen.config.ts` file.

A new `typesProvider` option allows for configuring the package used in the generated types file. If no value is provided, the correct provider is automatically detected. If one cannot be detected, `@prismicio/types` is used.

```typescript
// prismicCodegen.config.ts

import type { Config } from "prismic-ts-codegen";

const config: Config = {
  typesProvider: "@prismicio/client", // "@prismicio/types" can also be provided
};

export default config;
```

The generated file's import statement will reflect the `typesProvider` value.

```typescript
// Generated file

import * as prismic from "@prismicio/client";
```

### `generateTypes()`

The `generateTypes()` function accepts a new `typesProvider` option that specifies the package used in the generated types file. If no value is provided, `@prismicio/types` is used.

```typescript
generateTypes({
  typesProvider: "@prismicio/client", // "@prismicio/types" can also be provided
});
```

The output's import statement will reflect the `typesProvider` value.

```typescript
// output

import * as prismic from "@prismicio/client";
```

### `detectTypesProvider()`

The `detectTypesProvider()` helper attemps to detect a Node.js project's type provider. It loads `@prismicio/client` and `@prismicio/types` to determine which package is available, if any.

`@prismicio/client` v7 and above is supported. If <6 is found, it is ignored.

If no provider is detected, the helper returns `undefined`.

```typescript
await detectTypesProvider();
// => "@prismicio/client" | "@prismicio/types" | undefined
```

This function can be used in combination with `generateTypes()` if automatic types provider detection is desired when generating types.

```typescript
generateTypes({
  typesProvider: await detectTypesProvider(),
});
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐃
