### PR TITLE
fix: restore `@prismicio/client` integration

### DIFF
--- a/src/generateTypes.ts
+++ b/src/generateTypes.ts
@@ -31,8 +31,10 @@ export const generateTypes = (config: GenerateTypesConfig = {}) => {
 
 	const sourceFile = project.createSourceFile("types.d.ts");
 
+	const typesProvider = config.typesProvider || "@prismicio/types";
+
 	sourceFile.addImportDeclaration({
-		moduleSpecifier: config.typesProvider || "@prismicio/types",
+		moduleSpecifier: typesProvider,
 		namespaceImport: "prismic",
 		isTypeOnly: true,
 	});
@@ -86,12 +88,15 @@ export const generateTypes = (config: GenerateTypesConfig = {}) => {
 		config.clientIntegration?.includeCreateClientInterface ||
 		config.clientIntegration?.includeContentNamespace
 	) {
+		const clientNamespaceImportName =
+			typesProvider === "@prismicio/client" ? "prismicClient" : "prismic";
+
 		// This import declaration would be a duplicate if the types
 		// provider is @prismicio/client.
-		if (config.typesProvider !== "@prismicio/client") {
+		if (typesProvider !== "@prismicio/client") {
 			sourceFile.addImportDeclaration({
 				moduleSpecifier: "@prismicio/client",
-				namespaceImport: "prismic",
+				namespaceImport: clientNamespaceImportName,
 				isTypeOnly: true,
 			});
 		}
@@ -114,14 +119,14 @@ export const generateTypes = (config: GenerateTypesConfig = {}) => {
 							},
 							{
 								name: "options",
-								type: "prismic.ClientConfig",
+								type: `${clientNamespaceImportName}.ClientConfig`,
 								hasQuestionToken: true,
 							},
 						],
 						returnType:
 							(config.customTypeModels?.length || 0) > 0
-								? "prismic.Client<AllDocumentTypes>"
-								: "prismic.Client",
+								? `${clientNamespaceImportName}.Client<AllDocumentTypes>`
+								: `${clientNamespaceImportName}.Client`,
 					},
 				],
 			});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where the `@prismicio/client` integration would return `any` for all client query methods.

This only occurs when `@prismicio/types` is used as the types provider (the default). Both `@prismicio/types` and `@prismicio/client` were imported as `prismic`, causing a type error. Without a resolvable type, TypeScript returns `any`.

```typescript
// Output before
import type * as prismic from "@prismicio/types";
import type * as prismic from "@prismicio/client"; // Conflict!

// Output after
import type * as prismic from "@prismicio/types";
import type * as prismicClient from "@prismicio/client";
```

Note that when `@prismicio/client` is the types provider, only a single import is generated, resulting in no error.

```typescript
import type * as prismic from "@prismicio/client";
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
