### PR TITLE
fix: update content relationship field type from the deprecated `RelationField` to `ContentRelationshipField`

### DIFF
--- a/src/lib/addInterfacePropertiesForFields.ts
+++ b/src/lib/addInterfacePropertiesForFields.ts
@@ -196,10 +196,10 @@ const addInterfacePropertyForField = (
 							"customtypes" in config.model.config &&
 							config.model.config.customtypes &&
 							config.model.config.customtypes.length > 0
-								? `prismic.RelationField<${config.model.config.customtypes
+								? `prismic.ContentRelationshipField<${config.model.config.customtypes
 										.map((type) => `"${type}"`)
 										.join(" | ")}>`
-								: "prismic.RelationField",
+								: "prismic.ContentRelationshipField",
 						docs: buildFieldDocs({
 							id: config.id,
 							model: config.model,

--- a/test/generateTypes-contentRelationship.test.ts
+++ b/test/generateTypes-contentRelationship.test.ts
@@ -6,7 +6,7 @@ import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 it("is correctly typed", (ctx) => {
 	const model = ctx.mock.model.contentRelationship();
 
-	expectToHaveFieldType(model, "prismic.RelationField");
+	expectToHaveFieldType(model, "prismic.ContentRelationshipField");
 });
 
 it("is correctly typed", (ctx) => {
@@ -14,7 +14,10 @@ it("is correctly typed", (ctx) => {
 		customTypeIDs: ["foo", "bar"],
 	});
 
-	expectToHaveFieldType(model, 'prismic.RelationField<"foo" | "bar">');
+	expectToHaveFieldType(
+		model,
+		'prismic.ContentRelationshipField<"foo" | "bar">',
+	);
 });
 
 it("is correctly documented", (ctx) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates content relationship field's type from the depreacted `RelationField` to `ContentRelationshipField`.

`RelationField` was deprecated and replaced by `ContentRelationshipField` in `@prismicio/types` v0.2.3.

`RelationField` was removed in `@prismicio/client` v7.0.0 as part of the `@prismicio/types` -> `@prismicio/client` merge.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐏
