### PR TITLE
fix: replace deprecated `IntegrationFields` type with `IntegrationField` type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 			"devDependencies": {
 				"@prismicio/client": "^7.0.0",
 				"@prismicio/mock": "^0.2.0",
-				"@prismicio/types": "^0.2.0",
+				"@prismicio/types": "^0.2.8",
 				"@size-limit/preset-small-lib": "^8.2.4",
 				"@trivago/prettier-plugin-sort-imports": "^4.1.1",
 				"@types/common-tags": "^1.8.1",
@@ -51,7 +51,7 @@
 			},
 			"peerDependencies": {
 				"@prismicio/client": "^6.6 || ^7",
-				"@prismicio/types": "^0.2"
+				"@prismicio/types": "^0.2.8"
 			},
 			"peerDependenciesMeta": {
 				"@prismicio/client": {
@@ -951,9 +951,9 @@
 			}
 		},
 		"node_modules/@prismicio/types": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.7.tgz",
-			"integrity": "sha512-xHPBWg+lPcl8U97VB/2oYK3MJlQoVPZq91hbeQO8WRyvq+zgpNST3xFOTk8SkQpgoH6wd50AxGZELvPrpojajQ==",
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.8.tgz",
+			"integrity": "sha512-EmuYYil56U+UtEifMD/9TmLzpWliV+X6kypwPq47GNXmIXyFK1JsP3z872fUziXwoBjd2YILj28DNdYXlLOpXg==",
 			"engines": {
 				"node": ">=12.7.0"
 			}
@@ -9070,9 +9070,9 @@
 			}
 		},
 		"@prismicio/types": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.7.tgz",
-			"integrity": "sha512-xHPBWg+lPcl8U97VB/2oYK3MJlQoVPZq91hbeQO8WRyvq+zgpNST3xFOTk8SkQpgoH6wd50AxGZELvPrpojajQ=="
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.8.tgz",
+			"integrity": "sha512-EmuYYil56U+UtEifMD/9TmLzpWliV+X6kypwPq47GNXmIXyFK1JsP3z872fUziXwoBjd2YILj28DNdYXlLOpXg=="
 		},
 		"@rollup/plugin-typescript": {
 			"version": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 	"devDependencies": {
 		"@prismicio/client": "^7.0.0",
 		"@prismicio/mock": "^0.2.0",
-		"@prismicio/types": "^0.2.0",
+		"@prismicio/types": "^0.2.8",
 		"@size-limit/preset-small-lib": "^8.2.4",
 		"@trivago/prettier-plugin-sort-imports": "^4.1.1",
 		"@types/common-tags": "^1.8.1",
@@ -83,7 +83,7 @@
 	},
 	"peerDependencies": {
 		"@prismicio/client": "^6.6 || ^7",
-		"@prismicio/types": "^0.2"
+		"@prismicio/types": "^0.2.8"
 	},
 	"peerDependenciesMeta": {
 		"@prismicio/client": {

--- a/src/lib/addInterfacePropertiesForFields.ts
+++ b/src/lib/addInterfacePropertiesForFields.ts
@@ -173,8 +173,8 @@ const addInterfacePropertyForField = (
 			config.interface.addProperty({
 				name: config.id,
 				type: catalogType
-					? `prismic.IntegrationFields<${catalogType}>`
-					: "prismic.IntegrationFields",
+					? `prismic.IntegrationField<${catalogType}>`
+					: "prismic.IntegrationField",
 				docs: buildFieldDocs({
 					id: config.id,
 					model: config.model,

--- a/test/generateTypes-integration.test.ts
+++ b/test/generateTypes-integration.test.ts
@@ -9,7 +9,7 @@ import * as lib from "../src";
 it("is correctly typed", (ctx) => {
 	expectToHaveFieldType(
 		ctx.mock.model.integrationFields(),
-		"prismic.IntegrationFields",
+		"prismic.IntegrationField",
 	);
 });
 
@@ -38,10 +38,10 @@ it("can be customized with catalog-specific types", (ctx) => {
 
 	expect(
 		dataInterface.getPropertyOrThrow("bar").getTypeNodeOrThrow().getText(),
-	).toBe("prismic.IntegrationFields<AbcType>");
+	).toBe("prismic.IntegrationField<AbcType>");
 	expect(
 		dataInterface.getPropertyOrThrow("baz").getTypeNodeOrThrow().getText(),
-	).toBe("prismic.IntegrationFields<DefType>");
+	).toBe("prismic.IntegrationField<DefType>");
 });
 
 it("is correctly documented", (ctx) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes `prismic-ts-codegen` by using the correct non-deprecated `IntegrationField` type.

`IntegrationFields` (with an "s") was deprecated in `@prismicio/client` v7. Although `IntegrationFields` is still a valid API, TypeScript will warn about its deprecation status, and the type will eventually be removed from `@prismicio/cilent`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐰
