### PR TITLE
fix: compatibility with `@prismicio/client` v6

### DIFF
--- a/src/lib/buildCustomTypeDataType.ts
+++ b/src/lib/buildCustomTypeDataType.ts
@@ -1,4 +1,4 @@
-import { CustomTypeModel } from "@prismicio/client";
+import type { CustomTypeModel } from "@prismicio/client";
 import { source } from "common-tags";
 
 import { buildTypeName } from "../lib/buildTypeName";

--- a/src/lib/buildCustomTypeType.ts
+++ b/src/lib/buildCustomTypeType.ts
@@ -1,4 +1,4 @@
-import { CustomTypeModel } from "@prismicio/client";
+import type { CustomTypeModel } from "@prismicio/client";
 import { source } from "common-tags";
 import QuickLRU from "quick-lru";
 

--- a/src/lib/buildFieldDocs.ts
+++ b/src/lib/buildFieldDocs.ts
@@ -1,4 +1,4 @@
-import { CustomTypeModelField } from "@prismicio/client";
+import type { CustomTypeModelField } from "@prismicio/client";
 
 import { FieldPath } from "../types";
 

--- a/src/lib/buildFieldProperties.ts
+++ b/src/lib/buildFieldProperties.ts
@@ -1,8 +1,4 @@
-import {
-	CustomTypeModelField,
-	CustomTypeModelFieldType,
-	CustomTypeModelLinkSelectType,
-} from "@prismicio/client";
+import type { CustomTypeModelField } from "@prismicio/client";
 import { source, stripIndent } from "common-tags";
 
 import { AuxiliaryType, FieldConfigs, FieldPath } from "../types";
@@ -47,30 +43,30 @@ function buildFieldProperty(
 			: args.name;
 
 	switch (args.field.type) {
-		case CustomTypeModelFieldType.UID: {
+		case "UID": {
 			// UID fields are not included in Data.
 			break;
 		}
 
-		case CustomTypeModelFieldType.Boolean: {
+		case "Boolean": {
 			code = addLine(`${name}: prismic.BooleanField;`, code);
 
 			break;
 		}
 
-		case CustomTypeModelFieldType.Color: {
+		case "Color": {
 			code = addLine(`${name}: prismic.ColorField;`, code);
 
 			break;
 		}
 
-		case CustomTypeModelFieldType.Date: {
+		case "Date": {
 			code = addLine(`${name}: prismic.DateField;`, code);
 
 			break;
 		}
 
-		case CustomTypeModelFieldType.Embed: {
+		case "Embed": {
 			const providerTypes: string[] = [];
 
 			if (args.fieldConfigs.embed?.providerTypes) {
@@ -97,13 +93,13 @@ function buildFieldProperty(
 			break;
 		}
 
-		case CustomTypeModelFieldType.GeoPoint: {
+		case "GeoPoint": {
 			code = addLine(`${name}: prismic.GeoPointField;`, code);
 
 			break;
 		}
 
-		case CustomTypeModelFieldType.Image: {
+		case "Image": {
 			if (
 				args.field.config?.thumbnails &&
 				args.field.config.thumbnails.length > 0
@@ -120,7 +116,7 @@ function buildFieldProperty(
 			break;
 		}
 
-		case CustomTypeModelFieldType.Integration: {
+		case "IntegrationFields": {
 			const catalogType = args.field.config?.catalog
 				? args.fieldConfigs.integrationFields?.catalogTypes?.[
 						args.field.config.catalog
@@ -139,9 +135,9 @@ function buildFieldProperty(
 			break;
 		}
 
-		case CustomTypeModelFieldType.Link: {
+		case "Link": {
 			switch (args.field.config?.select) {
-				case CustomTypeModelLinkSelectType.Document: {
+				case "document": {
 					if (
 						"customtypes" in args.field.config &&
 						args.field.config.customtypes &&
@@ -162,7 +158,7 @@ function buildFieldProperty(
 					break;
 				}
 
-				case CustomTypeModelLinkSelectType.Media: {
+				case "media": {
 					code = addLine(`${name}: prismic.LinkToMediaField;`, code);
 
 					break;
@@ -176,13 +172,13 @@ function buildFieldProperty(
 			break;
 		}
 
-		case CustomTypeModelFieldType.Number: {
+		case "Number": {
 			code = addLine(`${name}: prismic.NumberField;`, code);
 
 			break;
 		}
 
-		case CustomTypeModelFieldType.StructuredText: {
+		case "StructuredText": {
 			const isTitleField =
 				args.field.config &&
 				"single" in args.field.config &&
@@ -200,7 +196,7 @@ function buildFieldProperty(
 			break;
 		}
 
-		case CustomTypeModelFieldType.Select: {
+		case "Select": {
 			const options: string[] =
 				args.field.config?.options?.map((option) => `"${option}"`) || [];
 			const optionsType = options.length ? buildUnion(options) : "string";
@@ -224,19 +220,19 @@ function buildFieldProperty(
 			break;
 		}
 
-		case CustomTypeModelFieldType.Text: {
+		case "Text": {
 			code = addLine(`${name}: prismic.KeyTextField;`, code);
 
 			break;
 		}
 
-		case CustomTypeModelFieldType.Timestamp: {
+		case "Timestamp": {
 			code = addLine(`${name}: prismic.TimestampField;`, code);
 
 			break;
 		}
 
-		case CustomTypeModelFieldType.Group: {
+		case "Group": {
 			const itemName = buildTypeName(
 				args.path[0].name,
 				"Document",
@@ -280,7 +276,7 @@ function buildFieldProperty(
 			break;
 		}
 
-		case CustomTypeModelFieldType.Slices: {
+		case "Slices": {
 			const choiceNames: string[] = [];
 
 			if (args.field.config?.choices) {

--- a/src/lib/buildSharedSliceType.ts
+++ b/src/lib/buildSharedSliceType.ts
@@ -1,4 +1,4 @@
-import { SharedSliceModel } from "@prismicio/client";
+import type { SharedSliceModel } from "@prismicio/client";
 import { source, stripIndent } from "common-tags";
 import QuickLRU from "quick-lru";
 

--- a/src/lib/checkHasUIDFIeld.ts
+++ b/src/lib/checkHasUIDFIeld.ts
@@ -1,4 +1,4 @@
-import { CustomTypeModel } from "@prismicio/client";
+import type { CustomTypeModel } from "@prismicio/client";
 
 export function checkHasUIDField(model: CustomTypeModel): boolean {
 	return "uid" in Object.assign({}, ...Object.values(model.json));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import sdk from "vite-plugin-sdk";
 export default defineConfig({
 	plugins: [
 		sdk({
-			internalDependencies: ["quick-lru"],
+			internalDependencies: ["@prismicio/client", "quick-lru"],
 		}),
 	],
 	build: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR restores compatibility with `@prismicio/client` v6 as a peer dependency.

`prismic-ts-codegen` v0.1.12 makes use of `@prismicio/client` v7's enums and types.

This PR replaces enum usage with strings (which remains type-checked). It also inlines `@prismicio/client` v7 as a dependency which should only be used at build time for types.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
