### PR TITLE
fix: restore support for Slice Zones without choices

### DIFF
--- a/src/lib/buildUnion.ts
+++ b/src/lib/buildUnion.ts
@@ -1,3 +1,3 @@
 export function buildUnion(types: string[]) {
-	return types.filter(Boolean).join(" | ");
+	return types.filter(Boolean).join(" | ") || "never";
 }

--- a/test/generateTypes-sliceZone.test.ts
+++ b/test/generateTypes-sliceZone.test.ts
@@ -79,6 +79,23 @@ it("creates a type alias to a union of all Slice types", (ctx) => {
 	);
 });
 
+it("handles Slice zones with no choices", (ctx) => {
+	const model = ctx.mock.model.customType({
+		id: "foo",
+		fields: {
+			bar: ctx.mock.model.sliceZone({
+				choices: {},
+			}),
+		},
+	});
+
+	const types = lib.generateTypes({ customTypeModels: [model] });
+	const file = parseSourceFile(types);
+	const sliceTypeAlias = file.getTypeAliasOrThrow("FooDocumentDataBarSlice");
+
+	expect(sliceTypeAlias.getTypeNodeOrThrow().getText()).toBe("never");
+});
+
 it("creates a type alias for each Slice", (ctx) => {
 	const model = ctx.mock.model.customType({
 		id: "foo",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where Slice Zones with no choices resulted in invalid syntax.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
