### PR TITLE
fix(cli): prevent `"Named export 'createClient' not found"` error

### DIFF
--- a/bin/prismic-ts-codegen.js
+++ b/bin/prismic-ts-codegen.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import("../dist/cli.cjs");

--- a/bin/prismic-ts-codegen.mjs
+++ b/bin/prismic-ts-codegen.mjs
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-import("../dist/cli.js");

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"bin": {
-		"prismic-ts-codegen": "./bin/prismic-ts-codegen.mjs"
+		"prismic-ts-codegen": "./bin/prismic-ts-codegen.js"
 	},
 	"files": [
 		"dist",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,12 @@ import sdk from "vite-plugin-sdk";
 export default defineConfig({
 	plugins: [
 		sdk({
-			internalDependencies: ["@prismicio/client", "quick-lru"],
+			internalDependencies: [
+				"@prismicio/client",
+				"meow",
+				"node-fetch",
+				"quick-lru",
+			],
 		}),
 	],
 	build: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

CLI is broken due to the way `@prismicio/client` is treated since `0.1.12`. This can be reproduced anywhere by simply running: `npx prismic-ts-codegen@0.1.16`.

This PR solves it by using the CJS export of the CLI which has proved more stable in the case of Slice Machine ([init](https://github.com/prismicio/slice-machine/blob/c3a5117c0d35e86020df6b5d16dd600e4231fda3/packages/init/bin/slicemachine-init.js), [start](https://github.com/prismicio/slice-machine/blob/c3a5117c0d35e86020df6b5d16dd600e4231fda3/packages/start-slicemachine/bin/start-slicemachine.js)). This forces us however to inline ESM-only dependencies (see Vite config)
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves: #56

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
![ComputerCatGIF](https://github.com/prismicio/prismic-ts-codegen/assets/25330882/8fcf1651-b294-44ae-846c-8f41e44544e0)