### PR TITLE
fix(cli): exit with non-zero error code when CLI has errors

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -142,11 +142,13 @@ const main = async () => {
 		} else {
 			if (error) {
 				console.error(error.message);
-
-				return;
+				process.exit(1);
 			}
 		}
 	}
 };
 
-main().catch((error) => console.error(error));
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
Allow other tools calling prismic-ts-codegen to detect errors by returning non-zero exit code from the process when errors occur.

## Types of changes

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description

The change signals a non-zero exit code (1) when prismic-ts-codegen execution end with an error. 
Currently if the tool is used in an automated build process, there is no way to interrupt the build other than scanning stdout for errors.

Using a non-zero code is a [standard practice](https://en.wikipedia.org/wiki/Exit_status) allowing other tools to detect failure scenarios.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

![image](https://github.com/prismicio/prismic-ts-codegen/assets/139180664/f1cae872-1b46-4732-8f11-4676fac7596f)