### PR TITLE
fix: replace `TitleField` with `RichTextField`

### DIFF
--- a/src/lib/buildFieldDocs.ts
+++ b/src/lib/buildFieldDocs.ts
@@ -18,15 +18,7 @@ function getHumanReadableFieldType(
 ): string {
 	switch (args.field.type) {
 		case "StructuredText": {
-			const isTitleField =
-				args.field.config &&
-				"single" in args.field.config &&
-				args.field.config.single &&
-				args.field.config.single
-					.split(",")
-					.every((blockType) => /heading/.test(blockType));
-
-			return isTitleField ? "Title" : "Rich Text";
+			return "Rich Text";
 		}
 
 		case "IntegrationFields": {

--- a/src/lib/buildFieldProperties.ts
+++ b/src/lib/buildFieldProperties.ts
@@ -203,19 +203,7 @@ function buildFieldProperty(
 		}
 
 		case "StructuredText": {
-			const isTitleField =
-				args.field.config &&
-				"single" in args.field.config &&
-				args.field.config.single &&
-				args.field.config.single
-					.split(",")
-					.every((blockType) => /heading/.test(blockType));
-
-			if (isTitleField) {
-				code = addLine(`${name}: prismic.TitleField;`, code);
-			} else {
-				code = addLine(`${name}: prismic.RichTextField;`, code);
-			}
+			code = addLine(`${name}: prismic.RichTextField;`, code);
 
 			break;
 		}

--- a/test/__snapshots__/generateTypes.test.ts.snap
+++ b/test/__snapshots__/generateTypes.test.ts.snap
@@ -83,12 +83,12 @@ export interface AcDocumentDataGroupItem {
 	/**
 	 * Morbi field in *Ac → Vulputate*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Porta non pulvinar
 	 * - **API ID Path**: ac.group[].nulla
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	nulla: prismic.TitleField;
+	nulla: prismic.RichTextField;
 }
 
 /**
@@ -188,12 +188,12 @@ export interface AcDocumentDataSliceZoneFooSlicePrimary {
 	/**
 	 * Nec field in *Ac → Slice zone → Volutpat Blandit → Primary*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Gravida fermentum et
 	 * - **API ID Path**: ac.sliceZone[].foo.primary.velit
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	velit: prismic.TitleField;
+	velit: prismic.RichTextField;
 }
 
 /**
@@ -293,12 +293,12 @@ export interface AcDocumentDataSliceZoneFooSliceItem {
 	/**
 	 * Sit field in *Ac → Slice zone → Volutpat Blandit → Items*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: At tempor commodo
 	 * - **API ID Path**: ac.sliceZone[].foo.items.et
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	et: prismic.TitleField;
+	et: prismic.RichTextField;
 }
 
 /**
@@ -403,13 +403,13 @@ interface AcDocumentData {
 	/**
 	 * Vel field in *Ac*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Ultrices iaculis nunc
 	 * - **API ID Path**: ac.diam_quam
 	 * - **Tab**: Main
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	diam_quam: prismic.TitleField;
+	diam_quam: prismic.RichTextField;
 	
 	/**
 	 * Vulputate field in *Ac*
@@ -587,12 +587,12 @@ export interface ImperdietDocumentDataSliceZoneFooSlicePrimary {
 	/**
 	 * Massa field in *Imperdiet → Slice zone → Tellus Mauris → Primary*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Elementum pulvinar etiam
 	 * - **API ID Path**: imperdiet.sliceZone[].foo.primary.pellentesque_habitant
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	pellentesque_habitant: prismic.TitleField;
+	pellentesque_habitant: prismic.RichTextField;
 }
 
 /**
@@ -730,13 +730,13 @@ interface ImperdietDocumentData {
 	/**
 	 * Morbi field in *Imperdiet*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Ante metus dictum
 	 * - **API ID Path**: imperdiet.ultrices_dui
 	 * - **Tab**: Main
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	ultrices_dui: prismic.TitleField;
+	ultrices_dui: prismic.RichTextField;
 	
 	/**
 	 * Neque field in *Imperdiet*
@@ -869,12 +869,12 @@ export interface VenenatisDocumentDataGroupItem {
 	/**
 	 * A field in *Venenatis → Amet*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Venenatis cras sed
 	 * - **API ID Path**: venenatis.group[].dignissim_enim
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	dignissim_enim: prismic.TitleField;
+	dignissim_enim: prismic.RichTextField;
 }
 
 /**
@@ -1193,12 +1193,12 @@ export interface SedDocumentDataGroupItem {
 	/**
 	 * Lacus field in *Sed → At*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Risus quis varius
 	 * - **API ID Path**: sed.group[].cras_fermentum
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	cras_fermentum: prismic.TitleField;
+	cras_fermentum: prismic.RichTextField;
 }
 
 /**
@@ -1343,12 +1343,12 @@ export interface SedDocumentDataSliceZoneFooSliceItem {
 	/**
 	 * Egestas field in *Sed → Slice zone → Nulla At → Items*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Nam libero justo
 	 * - **API ID Path**: sed.sliceZone[].foo.items.tempus_quam
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	tempus_quam: prismic.TitleField;
+	tempus_quam: prismic.RichTextField;
 }
 
 /**
@@ -1646,12 +1646,12 @@ export interface EtDocumentDataSliceZoneFooSlicePrimary {
 	/**
 	 * Sem field in *Et → Slice zone → Nibh Praesent → Primary*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Pretium quam vulputate
 	 * - **API ID Path**: et.sliceZone[].foo.primary.ullamcorper_eget
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	ullamcorper_eget: prismic.TitleField;
+	ullamcorper_eget: prismic.RichTextField;
 }
 
 /**
@@ -1741,12 +1741,12 @@ export interface EtDocumentDataSliceZoneFooSliceItem {
 	/**
 	 * Habitasse field in *Et → Slice zone → Nibh Praesent → Items*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Elit duis tristique
 	 * - **API ID Path**: et.sliceZone[].foo.items.rhoncus_aenean
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	rhoncus_aenean: prismic.TitleField;
+	rhoncus_aenean: prismic.RichTextField;
 }
 
 /**
@@ -1948,12 +1948,12 @@ export interface HendreritSliceNequePrimary {
 	/**
 	 * Tellus field in *Hendrerit → Neque → Primary*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Imperdiet dui accumsan
 	 * - **API ID Path**: hendrerit.neque.primary.ac
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	ac: prismic.TitleField;
+	ac: prismic.RichTextField;
 }
 
 /**
@@ -2151,12 +2151,12 @@ export interface AtSliceBlanditPrimary {
 	/**
 	 * Mi field in *At → Blandit → Primary*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Amet consectetur adipiscing
 	 * - **API ID Path**: at.blandit.primary.placerat_egestas
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	placerat_egestas: prismic.TitleField;
+	placerat_egestas: prismic.RichTextField;
 }
 
 /**
@@ -2256,12 +2256,12 @@ export interface AtSliceBlanditItem {
 	/**
 	 * Semper field in *At → Items*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Morbi leo urna
 	 * - **API ID Path**: at.items[].non
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	non: prismic.TitleField;
+	non: prismic.RichTextField;
 }
 
 /**
@@ -2374,12 +2374,12 @@ export interface DolorSliceEuPrimary {
 	/**
 	 * Sed field in *Dolor → Eu → Primary*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Quis lectus nulla
 	 * - **API ID Path**: dolor.eu.primary.morbi
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	morbi: prismic.TitleField;
+	morbi: prismic.RichTextField;
 }
 
 /**
@@ -2652,12 +2652,12 @@ export interface CondimentumSliceUrnaItem {
 	/**
 	 * Consectetur field in *Condimentum → Items*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Adipiscing elit ut
 	 * - **API ID Path**: condimentum.items[].faucibus_turpis
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	faucibus_turpis: prismic.TitleField;
+	faucibus_turpis: prismic.RichTextField;
 }
 
 /**
@@ -2865,12 +2865,12 @@ export interface PraesentSliceDolorItem {
 	/**
 	 * Sit field in *Praesent → Items*
 	 *
-	 * - **Field Type**: Title
+	 * - **Field Type**: Rich Text
 	 * - **Placeholder**: Lacus sed viverra
 	 * - **API ID Path**: praesent.items[].dui
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
-	dui: prismic.TitleField;
+	dui: prismic.RichTextField;
 }
 
 /**

--- a/test/generateTypes-title.test.ts
+++ b/test/generateTypes-title.test.ts
@@ -4,7 +4,7 @@ import { expectToHaveDocs } from "./__testutils__/expectToHaveDocs";
 import { expectToHaveFieldType } from "./__testutils__/expectToHaveFieldType";
 
 it("is correctly typed", (ctx) => {
-	expectToHaveFieldType(ctx.mock.model.title(), "prismic.TitleField");
+	expectToHaveFieldType(ctx.mock.model.title(), "prismic.RichTextField");
 });
 
 it("is correctly documented", (ctx) => {


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: N/A

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR replaces uses of `TitleField` with `RichTextField`. The title field does not exist in Slice Machine and is not something we support in new projects.

`@prismicio/client` will continue to have `TitleField` to support legacy projects. However, generated types will revert to `RichTextField`.

In practice, this change only affects the TSDocs a developer will see in their editor.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
