### PR TITLE
fix: update type exports for better esm interoperability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.9](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.8...v0.1.28-alpha.9) (2025-09-03)
+
+
+### Features
+
+* type import ([c4a68d3](https://github.com/prismicio/prismic-ts-codegen/commit/c4a68d3883c4c1b00c9383972696992a88292b60))
+
 ### [0.1.28-alpha.8](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.7...v0.1.28-alpha.8) (2025-09-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.3](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.2...v0.1.28-alpha.3) (2025-09-03)
+
 ### [0.1.28-alpha.2](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.1...v0.1.28-alpha.2) (2025-09-03)
 
 ### [0.1.28-alpha.1](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.0...v0.1.28-alpha.1) (2025-09-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.6](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.5...v0.1.28-alpha.6) (2025-09-03)
+
+
+### Bug Fixes
+
+* test patched version of client ([5ae45b6](https://github.com/prismicio/prismic-ts-codegen/commit/5ae45b614dba4142b2f33b7c91c7f3fedca749ca))
+
 ### [0.1.28-alpha.5](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.4...v0.1.28-alpha.5) (2025-09-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.1](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.0...v0.1.28-alpha.1) (2025-09-03)
+
 ### [0.1.28-alpha.0](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.27...v0.1.28-alpha.0) (2025-09-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.2](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.1...v0.1.28-alpha.2) (2025-09-03)
+
 ### [0.1.28-alpha.1](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.0...v0.1.28-alpha.1) (2025-09-03)
 
 ### [0.1.28-alpha.0](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.27...v0.1.28-alpha.0) (2025-09-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.8](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.7...v0.1.28-alpha.8) (2025-09-03)
+
+
+### Bug Fixes
+
+* test patched version of client ([3ae33ea](https://github.com/prismicio/prismic-ts-codegen/commit/3ae33ea286dbfa27899267a093952ec0c5149e4e))
+
 ### [0.1.28-alpha.7](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.6...v0.1.28-alpha.7) (2025-09-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.4](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.3...v0.1.28-alpha.4) (2025-09-03)
+
+
+### Features
+
+* consistent path ([4541f81](https://github.com/prismicio/prismic-ts-codegen/commit/4541f816f955395ab4f11bc1e6e7aac46bf120cf))
+
 ### [0.1.28-alpha.3](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.2...v0.1.28-alpha.3) (2025-09-03)
 
 ### [0.1.28-alpha.2](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.1...v0.1.28-alpha.2) (2025-09-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.0](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.27...v0.1.28-alpha.0) (2025-09-03)
+
+
+### Bug Fixes
+
+* correctly export type definitions ([260345a](https://github.com/prismicio/prismic-ts-codegen/commit/260345a17271bdfb718fc0fa7fad02c737dc73b0))
+
 ### [0.1.27](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.27-alpha.3...v0.1.27) (2025-06-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.5](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.4...v0.1.28-alpha.5) (2025-09-03)
+
+
+### Bug Fixes
+
+* remove type import keyword ([c804868](https://github.com/prismicio/prismic-ts-codegen/commit/c804868ac2550e324905fb29e24d6cee9e0e4254))
+
 ### [0.1.28-alpha.4](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.3...v0.1.28-alpha.4) (2025-09-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28-alpha.7](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.6...v0.1.28-alpha.7) (2025-09-03)
+
+
+### Bug Fixes
+
+* test patched version of client ([ead0ea0](https://github.com/prismicio/prismic-ts-codegen/commit/ead0ea0cce231890aa4e7be06d5737b6fd993fc8))
+
 ### [0.1.28-alpha.6](https://github.com/prismicio/prismic-ts-codegen/compare/v0.1.28-alpha.5...v0.1.28-alpha.6) (2025-09-03)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.5",
+	"version": "0.1.28-alpha.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.28-alpha.5",
+			"version": "0.1.28-alpha.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.1",
+	"version": "0.1.28-alpha.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.28-alpha.1",
+			"version": "0.1.28-alpha.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"prismic-ts-codegen": "bin/prismic-ts-codegen.js"
 			},
 			"devDependencies": {
-				"@prismicio/client": "7.19.0-alpha.0",
+				"@prismicio/client": "7.21.0-alpha.0",
 				"@prismicio/mock": "0.7.1",
 				"@size-limit/preset-small-lib": "^8.2.6",
 				"@trivago/prettier-plugin-sort-imports": "^4.3.0",
@@ -985,9 +985,9 @@
 			}
 		},
 		"node_modules/@prismicio/client": {
-			"version": "7.19.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.19.0-alpha.0.tgz",
-			"integrity": "sha512-Bj1+M7At8Z5JHmkPvWfhT2W+ZCNdlxFCZj1iBTd5aBfeSwJ3wRZjNpnKKqkq7Roqo8M6tPxQizXYO7XxXkbUiQ==",
+			"version": "7.21.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.21.0-alpha.0.tgz",
+			"integrity": "sha512-KuylY8hNtyMLLBTfNWRRTx9U7gjR+RTUXu+hyFMA8x6zJa+Md96C9uR/0vWgSp3mb/jO5rLwK1ZdoHgnJJut6w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"imgix-url-builder": "^0.0.6"
@@ -9340,9 +9340,9 @@
 			}
 		},
 		"@prismicio/client": {
-			"version": "7.19.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.19.0-alpha.0.tgz",
-			"integrity": "sha512-Bj1+M7At8Z5JHmkPvWfhT2W+ZCNdlxFCZj1iBTd5aBfeSwJ3wRZjNpnKKqkq7Roqo8M6tPxQizXYO7XxXkbUiQ==",
+			"version": "7.21.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.21.0-alpha.0.tgz",
+			"integrity": "sha512-KuylY8hNtyMLLBTfNWRRTx9U7gjR+RTUXu+hyFMA8x6zJa+Md96C9uR/0vWgSp3mb/jO5rLwK1ZdoHgnJJut6w==",
 			"requires": {
 				"imgix-url-builder": "^0.0.6"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.3",
+	"version": "0.1.28-alpha.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.28-alpha.3",
+			"version": "0.1.28-alpha.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.2",
+	"version": "0.1.28-alpha.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.28-alpha.2",
+			"version": "0.1.28-alpha.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"prismic-ts-codegen": "bin/prismic-ts-codegen.js"
 			},
 			"devDependencies": {
-				"@prismicio/client": "7.21.0-alpha.0",
+				"@prismicio/client": "7.21.0-alpha.1",
 				"@prismicio/mock": "0.7.1",
 				"@size-limit/preset-small-lib": "^8.2.6",
 				"@trivago/prettier-plugin-sort-imports": "^4.3.0",
@@ -985,9 +985,9 @@
 			}
 		},
 		"node_modules/@prismicio/client": {
-			"version": "7.21.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.21.0-alpha.0.tgz",
-			"integrity": "sha512-KuylY8hNtyMLLBTfNWRRTx9U7gjR+RTUXu+hyFMA8x6zJa+Md96C9uR/0vWgSp3mb/jO5rLwK1ZdoHgnJJut6w==",
+			"version": "7.21.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.21.0-alpha.1.tgz",
+			"integrity": "sha512-4iplH90bRoTRhnSR03lJxYB/8ZOrvkT6dGujt+ZtewcYmr6UAs2K5xlle0Vmi1jeTMshiql7wHqTChWVTmojJw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"imgix-url-builder": "^0.0.6"
@@ -9340,9 +9340,9 @@
 			}
 		},
 		"@prismicio/client": {
-			"version": "7.21.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.21.0-alpha.0.tgz",
-			"integrity": "sha512-KuylY8hNtyMLLBTfNWRRTx9U7gjR+RTUXu+hyFMA8x6zJa+Md96C9uR/0vWgSp3mb/jO5rLwK1ZdoHgnJJut6w==",
+			"version": "7.21.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.21.0-alpha.1.tgz",
+			"integrity": "sha512-4iplH90bRoTRhnSR03lJxYB/8ZOrvkT6dGujt+ZtewcYmr6UAs2K5xlle0Vmi1jeTMshiql7wHqTChWVTmojJw==",
 			"requires": {
 				"imgix-url-builder": "^0.0.6"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.8",
+	"version": "0.1.28-alpha.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.28-alpha.8",
+			"version": "0.1.28-alpha.9",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.4",
+	"version": "0.1.28-alpha.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.28-alpha.4",
+			"version": "0.1.28-alpha.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.7",
+	"version": "0.1.28-alpha.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.28-alpha.7",
+			"version": "0.1.28-alpha.8",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.0",
+	"version": "0.1.28-alpha.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.28-alpha.0",
+			"version": "0.1.28-alpha.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.27",
+	"version": "0.1.28-alpha.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.27",
+			"version": "0.1.28-alpha.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.6",
+	"version": "0.1.28-alpha.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prismic-ts-codegen",
-			"version": "0.1.28-alpha.6",
+			"version": "0.1.28-alpha.7",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/custom-types-client": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"prismic-ts-codegen": "bin/prismic-ts-codegen.js"
 			},
 			"devDependencies": {
-				"@prismicio/client": "7.18.0",
+				"@prismicio/client": "7.19.0-alpha.0",
 				"@prismicio/mock": "0.7.1",
 				"@size-limit/preset-small-lib": "^8.2.6",
 				"@trivago/prettier-plugin-sort-imports": "^4.3.0",
@@ -985,9 +985,9 @@
 			}
 		},
 		"node_modules/@prismicio/client": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.18.0.tgz",
-			"integrity": "sha512-x6QNrntAsNc5mvClg0YpDLFsqeVA89963HbNtLBDzDWfIFdNXYRQARxo0aUjjUxn1e7fSynIaVdBht7DsQGxjQ==",
+			"version": "7.19.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.19.0-alpha.0.tgz",
+			"integrity": "sha512-Bj1+M7At8Z5JHmkPvWfhT2W+ZCNdlxFCZj1iBTd5aBfeSwJ3wRZjNpnKKqkq7Roqo8M6tPxQizXYO7XxXkbUiQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"imgix-url-builder": "^0.0.6"
@@ -9340,9 +9340,9 @@
 			}
 		},
 		"@prismicio/client": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.18.0.tgz",
-			"integrity": "sha512-x6QNrntAsNc5mvClg0YpDLFsqeVA89963HbNtLBDzDWfIFdNXYRQARxo0aUjjUxn1e7fSynIaVdBht7DsQGxjQ==",
+			"version": "7.19.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.19.0-alpha.0.tgz",
+			"integrity": "sha512-Bj1+M7At8Z5JHmkPvWfhT2W+ZCNdlxFCZj1iBTd5aBfeSwJ3wRZjNpnKKqkq7Roqo8M6tPxQizXYO7XxXkbUiQ==",
 			"requires": {
 				"imgix-url-builder": "^0.0.6"
 			}

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"quick-lru": "^6.1.2"
 	},
 	"devDependencies": {
-		"@prismicio/client": "7.19.0-alpha.0",
+		"@prismicio/client": "7.21.0-alpha.0",
 		"@prismicio/mock": "0.7.1",
 		"@size-limit/preset-small-lib": "^8.2.6",
 		"@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.7",
+	"version": "0.1.28-alpha.8",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.3",
+	"version": "0.1.28-alpha.4",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.2",
+	"version": "0.1.28-alpha.3",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.27",
+	"version": "0.1.28-alpha.0",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.6",
+	"version": "0.1.28-alpha.7",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.5",
+	"version": "0.1.28-alpha.6",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	"typesVersions": {
 		"*": {
 			"*": [
-				"dist/index.d.ts"
+				"./dist/index.d.ts"
 			]
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -15,14 +15,27 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"require": "./dist/index.cjs",
-			"import": "./dist/index.js"
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.cjs"
+			},
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			}
 		},
 		"./package.json": "./package.json"
 	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
+	"typesVersions": {
+		"*": {
+			"*": [
+				"dist/index.d.ts"
+			]
+		}
+	},
 	"bin": {
 		"prismic-ts-codegen": "./bin/prismic-ts-codegen.js"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.4",
+	"version": "0.1.28-alpha.5",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.1",
+	"version": "0.1.28-alpha.2",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"quick-lru": "^6.1.2"
 	},
 	"devDependencies": {
-		"@prismicio/client": "7.21.0-alpha.0",
+		"@prismicio/client": "7.21.0-alpha.1",
 		"@prismicio/mock": "0.7.1",
 		"@size-limit/preset-small-lib": "^8.2.6",
 		"@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"quick-lru": "^6.1.2"
 	},
 	"devDependencies": {
-		"@prismicio/client": "7.18.0",
+		"@prismicio/client": "7.19.0-alpha.0",
 		"@prismicio/mock": "0.7.1",
 		"@size-limit/preset-small-lib": "^8.2.6",
 		"@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.8",
+	"version": "0.1.28-alpha.9",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic-ts-codegen",
-	"version": "0.1.28-alpha.0",
+	"version": "0.1.28-alpha.1",
 	"description": "An experimental Prismic model-to-TypeScript-type generator",
 	"keywords": [
 		"typescript",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import type { CustomTypeModelFieldType } from "@prismicio/client";
+import { CustomTypeModelFieldType } from "@prismicio/client";
 
 export const CUSTOM_TYPES_DOCUMENTATION_URL =
 	"https://prismic.io/docs/content-modeling";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { CustomTypeModelFieldType } from "@prismicio/client";
+import type { CustomTypeModelFieldType } from "@prismicio/client";
 
 export const CUSTOM_TYPES_DOCUMENTATION_URL =
 	"https://prismic.io/docs/content-modeling";
@@ -30,7 +30,7 @@ export const FIELD_DOCUMENTATION_URLS = {
 	Choice: "https://prismic.io/docs/slices",
 } satisfies Record<
 	Exclude<
-		(typeof CustomTypeModelFieldType)[keyof typeof CustomTypeModelFieldType],
+		CustomTypeModelFieldType[keyof CustomTypeModelFieldType],
 		"Range" | "Separator"
 	>,
 	string | Record<string, string>


### PR DESCRIPTION
### Description

Fixing the following issue when using Node <=18 with a regular ESM import:

<img width="758" height="290" alt="Screenshot 2025-09-03 at 11 40 54" src="https://github.com/user-attachments/assets/f9c7494f-c054-4e91-87a1-7b71448ace25" />

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
