### PR TITLE
fix: crash from change to ESM

### DIFF
--- a/bin/prismic-ts-codegen.js
+++ b/bin/prismic-ts-codegen.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-import("../dist/cli.cjs");
+import("../dist/cli.mjs");

--- a/package.json
+++ b/package.json
@@ -21,14 +21,9 @@
 		"bin"
 	],
 	"type": "module",
-	"main": "./dist/index.cjs",
-	"module": "./dist/index.js",
 	"types": "./dist/index.d.cts",
 	"exports": {
-		".": {
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
-		},
+		".": "./dist/index.mjs",
 		"./package.json": "./package.json"
 	},
 	"publishConfig": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 		"bin"
 	],
 	"type": "module",
-	"types": "./dist/index.d.cts",
 	"exports": {
 		".": "./dist/index.mjs",
 		"./package.json": "./package.json"

--- a/package.json
+++ b/package.json
@@ -22,10 +22,7 @@
 	],
 	"type": "module",
 	"exports": {
-		".": {
-			"types": "./dist/index.d.mts",
-			"default": "./dist/index.mjs"
-		},
+		".": "./dist/index.mjs",
 		"./package.json": "./package.json"
 	},
 	"publishConfig": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
 	],
 	"type": "module",
 	"exports": {
-		".": "./dist/index.mjs",
+		".": {
+			"types": "./dist/index.d.mts",
+			"default": "./dist/index.mjs"
+		},
 		"./package.json": "./package.json"
 	},
 	"publishConfig": {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
 		index: "./src/index.ts",
 		cli: "./src/cli/index.ts",
 	},
-	format: ["esm", "cjs"],
-	platform: "neutral",
+	format: "esm",
+	platform: "node",
 	unbundle: true,
 	sourcemap: true,
 	exports: {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 	},
 	format: "esm",
 	platform: "node",
+	dts: true,
 	unbundle: true,
 	sourcemap: true,
 	exports: {


### PR DESCRIPTION
Resolves: #79

### Description

Drop CJS output and ship ESM only. Updates the build config, package exports, and CLI binary entry point.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/prismic-ts-codegen/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Drops CommonJS artifacts and updates package `exports`/CLI entrypoints, which can break consumers still using `require()` or expecting `index.cjs`/`cli.cjs`. Build now targets Node ESM specifically, so publish/output compatibility should be revalidated.
> 
> **Overview**
> Switches the package to **ESM-only distribution** by removing CJS entrypoints from `package.json` and exporting only `./dist/index.mjs`.
> 
> Updates the CLI launcher to load `./dist/cli.mjs`, and adjusts `tsdown` build settings to emit ESM for the Node platform with `.d.ts` generation enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ae62e2038f4f770392285199b8f682a9fecef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->